### PR TITLE
chore: make LeanStore runnable on M1 chips

### DIFF
--- a/source/concurrency-recovery/Logging.cpp
+++ b/source/concurrency-recovery/Logging.cpp
@@ -154,6 +154,7 @@ void Logging::SubmitWALEntryComplex(u64 totalSize) {
   COUNTERS_BLOCK() {
     WorkerCounters::myCounters().wal_write_bytes += totalSize;
   }
+  DCHECK(totalSize % 8 == 0);
   mWalBuffered += totalSize;
   UpdateWalFlushReq();
 }

--- a/source/concurrency-recovery/Recovery.cpp
+++ b/source/concurrency-recovery/Recovery.cpp
@@ -15,28 +15,28 @@ void Recovery::Analysis() {
     auto walEntry = reinterpret_cast<WALEntry*>(&page);
     switch (walEntry->type) {
     case WALEntry::TYPE::TX_START: {
-      DCHECK(bytesRead == walEntry->size);
+      DCHECK_EQ(bytesRead, walEntry->size);
       DCHECK(mActiveTxTable.find(walEntry->mTxId) == mActiveTxTable.end());
       mActiveTxTable.emplace(std::make_pair(walEntry->mTxId, offset));
       offset += bytesRead;
       continue;
     }
     case WALEntry::TYPE::TX_COMMIT: {
-      DCHECK(bytesRead == walEntry->size);
+      DCHECK_EQ(bytesRead, walEntry->size);
       DCHECK(mActiveTxTable.find(walEntry->mTxId) != mActiveTxTable.end());
       mActiveTxTable[walEntry->mTxId] = offset;
       offset += bytesRead;
       continue;
     }
     case WALEntry::TYPE::TX_ABORT: {
-      DCHECK(bytesRead == walEntry->size);
+      DCHECK_EQ(bytesRead, walEntry->size);
       DCHECK(mActiveTxTable.find(walEntry->mTxId) != mActiveTxTable.end());
       mActiveTxTable[walEntry->mTxId] = offset;
       offset += bytesRead;
       continue;
     }
     case WALEntry::TYPE::TX_FINISH: {
-      DCHECK(bytesRead == walEntry->size);
+      DCHECK_EQ(bytesRead, walEntry->size);
       DCHECK(mActiveTxTable.find(walEntry->mTxId) != mActiveTxTable.end());
       mActiveTxTable.erase(walEntry->mTxId);
       offset += bytesRead;
@@ -49,7 +49,7 @@ void Recovery::Analysis() {
       bytesRead += ReadWalEntry(leftOffset, leftSize, leftDest);
 
       auto complexEntry = reinterpret_cast<WALEntryComplex*>(walEntryPtr);
-      DCHECK(bytesRead == complexEntry->size);
+      DCHECK_EQ(bytesRead, complexEntry->size);
       DCHECK(mActiveTxTable.find(walEntry->mTxId) != mActiveTxTable.end());
       mActiveTxTable[walEntry->mTxId] = offset;
 

--- a/source/concurrency-recovery/WALEntry.hpp
+++ b/source/concurrency-recovery/WALEntry.hpp
@@ -98,7 +98,6 @@ public:
         << ", CRC calculated based on the actual WALEntry: " << actualCRC;
   }
 };
-
 class WALEntrySimple : public WALEntry {
 public:
   WALEntrySimple(LID lsn, u64 size, TYPE type) : WALEntry(lsn, size, type) {

--- a/source/storage/btree/core/BTreeNode.hpp
+++ b/source/storage/btree/core/BTreeNode.hpp
@@ -14,7 +14,6 @@
 #include <cassert>
 #include <cstring>
 #include <fstream>
-#include <immintrin.h>
 #include <string>
 
 using namespace std;

--- a/source/storage/buffer-manager/GuardedBufferFrame.hpp
+++ b/source/storage/buffer-manager/GuardedBufferFrame.hpp
@@ -188,6 +188,7 @@ public:
 
     const auto pageId = mBf->header.mPageId;
     const auto treeId = mBf->page.mBTreeId;
+    payloadSize = ((payloadSize - 1) / 8  + 1) * 8;  
     // TODO: verify
     auto handler =
         cr::Worker::my().mLogging.ReserveWALEntryComplex<WT, Args...>(

--- a/source/threads/UT.hpp
+++ b/source/threads/UT.hpp
@@ -5,7 +5,6 @@
 #include "utils/Misc.hpp"
 #include "utils/RandomGenerator.hpp"
 // -------------------------------------------------------------------------------------
-#include <emmintrin.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <libaio.h>


### PR DESCRIPTION
- Removed some unused headers that exist only on x86.
- Enforce alignment of all WAL entries to `16`.