### PR TITLE
fix: use jump free and scoped array

### DIFF
--- a/source/concurrency-recovery/HistoryTree.cpp
+++ b/source/concurrency-recovery/HistoryTree.cpp
@@ -150,10 +150,10 @@ void HistoryTree::purgeVersions(WORKERID workerId, TXID from_tx_id,
                                 TXID to_tx_id, RemoveVersionCallback cb,
                                 [[maybe_unused]] const u64 limit) {
   auto keySize = sizeof(to_tx_id);
-  auto keyBuffer = utils::ScopedArray<u8>(FLAGS_page_size);
-  utils::fold(keyBuffer.get(), from_tx_id);
-  Slice key(keyBuffer.get(), keySize);
-  auto payload = utils::ScopedArray<u8>(FLAGS_page_size);
+  auto keyBuffer = utils::JumpScopedArray<u8>(FLAGS_page_size);
+  utils::fold(keyBuffer->get(), from_tx_id);
+  Slice key(keyBuffer->get(), keySize);
+  auto payload = utils::JumpScopedArray<u8>(FLAGS_page_size);
   u16 payload_length;
   volatile u64 removed_versions = 0;
   BTreeLL* volatile btree = remove_btrees[workerId];
@@ -189,15 +189,15 @@ void HistoryTree::purgeVersions(WORKERID workerId, TXID from_tx_id,
           const bool called_before = versionContainer.called_before;
           versionContainer.called_before = true;
           keySize = iterator.key().length();
-          std::memcpy(keyBuffer.get(), iterator.key().data(), keySize);
+          std::memcpy(keyBuffer->get(), iterator.key().data(), keySize);
           payload_length = iterator.value().length() - sizeof(VersionMeta);
-          std::memcpy(payload.get(), versionContainer.payload, payload_length);
-          key = Slice(keyBuffer.get(), keySize + 1);
+          std::memcpy(payload->get(), versionContainer.payload, payload_length);
+          key = Slice(keyBuffer->get(), keySize + 1);
           iterator.removeCurrent();
           removed_versions = removed_versions + 1;
           iterator.MarkAsDirty();
           iterator.reset();
-          cb(current_tx_id, treeId, payload.get(), payload_length,
+          cb(current_tx_id, treeId, payload->get(), payload_length,
              called_before);
           goto restartrem;
         } else {
@@ -212,7 +212,7 @@ void HistoryTree::purgeVersions(WORKERID workerId, TXID from_tx_id,
   }
 
   btree = update_btrees[workerId];
-  utils::fold(keyBuffer.get(), from_tx_id);
+  utils::fold(keyBuffer->get(), from_tx_id);
 
   // Attention: no cross worker gc in sync
   Session* volatile session = &update_sessions[workerId];
@@ -227,11 +227,11 @@ void HistoryTree::purgeVersions(WORKERID workerId, TXID from_tx_id,
 
         if (guardedLeaf->mLowerFence.length == 0) {
           // Allocate in the stack, freed when the calling function exits.
-          auto lastKey = utils::ScopedArray<u8>(
+          auto lastKey = utils::JumpScopedArray<u8>(
               guardedLeaf->getFullKeyLen(guardedLeaf->mNumSeps - 1));
-          guardedLeaf->copyFullKey(guardedLeaf->mNumSeps - 1, lastKey.get());
+          guardedLeaf->copyFullKey(guardedLeaf->mNumSeps - 1, lastKey->get());
           TXID last_key_tx_id;
-          utils::unfold(lastKey.get(), last_key_tx_id);
+          utils::unfold(lastKey->get(), last_key_tx_id);
           if (last_key_tx_id > to_tx_id) {
             should_try = false;
           }
@@ -269,17 +269,17 @@ void HistoryTree::purgeVersions(WORKERID workerId, TXID from_tx_id,
             }
             // Allocate in the stack, freed when the calling function exits.
             auto firstKey =
-                utils::ScopedArray<u8>(guardedLeaf->getFullKeyLen(0));
-            guardedLeaf->copyFullKey(0, firstKey.get());
+                utils::JumpScopedArray<u8>(guardedLeaf->getFullKeyLen(0));
+            guardedLeaf->copyFullKey(0, firstKey->get());
             TXID first_key_tx_id;
-            utils::unfold(firstKey.get(), first_key_tx_id);
+            utils::unfold(firstKey->get(), first_key_tx_id);
 
             // Allocate in the stack, freed when the calling function exits.
-            auto lastKey = utils::ScopedArray<u8>(
+            auto lastKey = utils::JumpScopedArray<u8>(
                 guardedLeaf->getFullKeyLen(guardedLeaf->mNumSeps - 1));
-            guardedLeaf->copyFullKey(guardedLeaf->mNumSeps - 1, lastKey.get());
+            guardedLeaf->copyFullKey(guardedLeaf->mNumSeps - 1, lastKey->get());
             TXID last_key_tx_id;
-            utils::unfold(lastKey.get(), last_key_tx_id);
+            utils::unfold(lastKey->get(), last_key_tx_id);
             if (first_key_tx_id >= from_tx_id && to_tx_id >= last_key_tx_id) {
               // Purge the whole page
               removed_versions = removed_versions + guardedLeaf->mNumSeps;
@@ -317,11 +317,11 @@ void HistoryTree::visitRemoveVersions(
   // [from, to]
   BTreeLL* btree = remove_btrees[workerId];
   auto keySize = sizeof(to_tx_id);
-  auto keyBuffer = utils::ScopedArray<u8>(FLAGS_page_size);
+  auto keyBuffer = utils::JumpScopedArray<u8>(FLAGS_page_size);
   u64 offset = 0;
-  offset += utils::fold(keyBuffer.get() + offset, from_tx_id);
-  Slice key(keyBuffer.get(), keySize);
-  auto payload = utils::ScopedArray<u8>(FLAGS_page_size);
+  offset += utils::fold(keyBuffer->get() + offset, from_tx_id);
+  Slice key(keyBuffer->get(), keySize);
+  auto payload = utils::JumpScopedArray<u8>(FLAGS_page_size);
   u16 payload_length;
 
   JUMPMU_TRY() {
@@ -341,15 +341,16 @@ void HistoryTree::visitRemoveVersions(
         ENSURE(called_before == false);
         versionContainer.called_before = true;
         keySize = iterator.key().length();
-        std::memcpy(keyBuffer.get(), iterator.key().data(), keySize);
+        std::memcpy(keyBuffer->get(), iterator.key().data(), keySize);
         payload_length = iterator.value().length() - sizeof(VersionMeta);
-        std::memcpy(payload.get(), versionContainer.payload, payload_length);
-        key = Slice(keyBuffer.get(), keySize + 1);
+        std::memcpy(payload->get(), versionContainer.payload, payload_length);
+        key = Slice(keyBuffer->get(), keySize + 1);
         if (!called_before) {
           iterator.MarkAsDirty();
         }
         iterator.reset();
-        cb(current_tx_id, treeId, payload.get(), payload_length, called_before);
+        cb(current_tx_id, treeId, payload->get(), payload_length,
+           called_before);
         goto restart;
       } else {
         break;

--- a/source/storage/btree/core/BTreeGeneric.cpp
+++ b/source/storage/btree/core/BTreeGeneric.cpp
@@ -90,8 +90,8 @@ void BTreeGeneric::trySplit(BufferFrame& toSplit, s16 favoredSplitPos) {
         BTreeNode::SeparatorInfo{guardedChild->getFullKeyLen(favoredSplitPos),
                                  static_cast<u16>(favoredSplitPos), false};
   }
-  auto sepKeyBuf = utils::ScopedArray<u8>(sepInfo.length);
-  auto sepKey = sepKeyBuf.get();
+  auto sepKeyBuf = utils::JumpScopedArray<u8>(sepInfo.length);
+  auto sepKey = sepKeyBuf->get();
   if (isMetaNode(guardedParent)) {
     // split the root node
     auto xGuardedParent = ExclusiveGuardedBufferFrame(std::move(guardedParent));
@@ -416,17 +416,17 @@ s16 BTreeGeneric::mergeLeftIntoRight(
 
   u16 newLeftUpperFenceSize = xGuardedLeft->getFullKeyLen(till_slot_id - 1);
   ENSURE(newLeftUpperFenceSize > 0);
-  auto newLeftUpperFenceBuf = utils::ScopedArray<u8>(newLeftUpperFenceSize);
-  auto newLeftUpperFence = newLeftUpperFenceBuf.get();
+  auto newLeftUpperFenceBuf = utils::JumpScopedArray<u8>(newLeftUpperFenceSize);
+  auto newLeftUpperFence = newLeftUpperFenceBuf->get();
   xGuardedLeft->copyFullKey(till_slot_id - 1, newLeftUpperFence);
 
   if (!xGuardedParent->prepareInsert(newLeftUpperFenceSize, 0)) {
     return 0; // false
   }
 
-  auto nodeBuf = utils::ScopedArray<u8>(BTreeNode::Size());
+  auto nodeBuf = utils::JumpScopedArray<u8>(BTreeNode::Size());
   {
-    auto tmp = BTreeNode::Init(nodeBuf.get(), true);
+    auto tmp = BTreeNode::Init(nodeBuf->get(), true);
 
     tmp->setFences(Slice(newLeftUpperFence, newLeftUpperFenceSize),
                    xGuardedRight->GetUpperFence());
@@ -442,7 +442,7 @@ s16 BTreeGeneric::mergeLeftIntoRight(
                Slice(newLeftUpperFence, newLeftUpperFenceSize)) == 1);
   }
   {
-    auto tmp = BTreeNode::Init(nodeBuf.get(), true);
+    auto tmp = BTreeNode::Init(nodeBuf->get(), true);
 
     tmp->setFences(xGuardedLeft->GetLowerFence(),
                    Slice(newLeftUpperFence, newLeftUpperFenceSize));
@@ -483,11 +483,11 @@ BTreeGeneric::XMergeReturnCode BTreeGeneric::XMerge(
   u8 pages_count = 1;
   s16 max_right;
   auto guardedNodesBuf =
-      utils::ScopedArray<GuardedBufferFrame<BTreeNode>>(MAX_MERGE_PAGES);
-  auto guardedNodes = guardedNodesBuf.get();
+      utils::JumpScopedArray<GuardedBufferFrame<BTreeNode>>(MAX_MERGE_PAGES);
+  auto guardedNodes = guardedNodesBuf->get();
 
-  auto fullyMergedBuf = utils::ScopedArray<bool>(MAX_MERGE_PAGES);
-  auto fullyMerged = fullyMergedBuf.get();
+  auto fullyMergedBuf = utils::JumpScopedArray<bool>(MAX_MERGE_PAGES);
+  auto fullyMerged = fullyMergedBuf->get();
 
   guardedNodes[0] = std::move(guardedChild);
   fullyMerged[0] = false;

--- a/source/storage/btree/core/BTreeNode.cpp
+++ b/source/storage/btree/core/BTreeNode.cpp
@@ -104,8 +104,8 @@ void BTreeNode::compactify() {
   u16 should = freeSpaceAfterCompaction();
   static_cast<void>(should);
 
-  auto tmpNodeBuf = utils::ScopedArray<u8>(BTreeNode::Size());
-  auto tmp = BTreeNode::Init(tmpNodeBuf.get(), mIsLeaf);
+  auto tmpNodeBuf = utils::JumpScopedArray<u8>(BTreeNode::Size());
+  auto tmp = BTreeNode::Init(tmpNodeBuf->get(), mIsLeaf);
 
   tmp->setFences(GetLowerFence(), GetUpperFence());
   copyKeyValueRange(tmp, 0, 0, mNumSeps);
@@ -119,8 +119,8 @@ u32 BTreeNode::mergeSpaceUpperBound(
     ExclusiveGuardedBufferFrame<BTreeNode>& xGuardedRight) {
   DCHECK(xGuardedRight->mIsLeaf);
 
-  auto tmpNodeBuf = utils::ScopedArray<u8>(BTreeNode::Size());
-  auto tmp = BTreeNode::Init(tmpNodeBuf.get(), true);
+  auto tmpNodeBuf = utils::JumpScopedArray<u8>(BTreeNode::Size());
+  auto tmp = BTreeNode::Init(tmpNodeBuf->get(), true);
 
   tmp->setFences(GetLowerFence(), xGuardedRight->GetUpperFence());
   u32 leftGrow = (mPrefixSize - tmp->mPrefixSize) * mNumSeps;
@@ -147,8 +147,8 @@ bool BTreeNode::merge(u16 slotId,
     assert(xGuardedRight->mIsLeaf);
     assert(xGuardedParent->isInner());
 
-    auto tmpNodeBuf = utils::ScopedArray<u8>(BTreeNode::Size());
-    auto tmp = BTreeNode::Init(tmpNodeBuf.get(), true);
+    auto tmpNodeBuf = utils::JumpScopedArray<u8>(BTreeNode::Size());
+    auto tmp = BTreeNode::Init(tmpNodeBuf->get(), true);
 
     tmp->setFences(GetLowerFence(), xGuardedRight->GetUpperFence());
     u16 leftGrow = (mPrefixSize - tmp->mPrefixSize) * mNumSeps;
@@ -175,8 +175,8 @@ bool BTreeNode::merge(u16 slotId,
     assert(!xGuardedRight->mIsLeaf);
     assert(xGuardedParent->isInner());
 
-    auto tmpNodeBuf = utils::ScopedArray<u8>(BTreeNode::Size());
-    auto tmp = BTreeNode::Init(tmpNodeBuf.get(), mIsLeaf);
+    auto tmpNodeBuf = utils::JumpScopedArray<u8>(BTreeNode::Size());
+    auto tmp = BTreeNode::Init(tmpNodeBuf->get(), mIsLeaf);
 
     tmp->setFences(GetLowerFence(), xGuardedRight->GetUpperFence());
     u16 leftGrow = (mPrefixSize - tmp->mPrefixSize) * mNumSeps;
@@ -193,10 +193,10 @@ bool BTreeNode::merge(u16 slotId,
       return false;
     copyKeyValueRange(tmp, 0, 0, mNumSeps);
     // Allocate in the stack, freed when the calling function exits.
-    auto extraKey = utils::ScopedArray<u8>(extraKeyLength);
-    xGuardedParent->copyFullKey(slotId, extraKey.get());
+    auto extraKey = utils::JumpScopedArray<u8>(extraKeyLength);
+    xGuardedParent->copyFullKey(slotId, extraKey->get());
     tmp->storeKeyValue(
-        mNumSeps, Slice(extraKey.get(), extraKeyLength),
+        mNumSeps, Slice(extraKey->get(), extraKeyLength),
         Slice(reinterpret_cast<u8*>(&mRightMostChildSwip), sizeof(SwipType)));
     tmp->mNumSeps++;
     xGuardedRight->copyKeyValueRange(tmp, tmp->mNumSeps, 0,
@@ -264,8 +264,8 @@ void BTreeNode::copyKeyValueRange(BTreeNode* dst, u16 dstSlot, u16 srcSlot,
 
 void BTreeNode::copyKeyValue(u16 srcSlot, BTreeNode* dst, u16 dstSlot) {
   u16 fullLength = getFullKeyLen(srcSlot);
-  auto keyBuf = utils::ScopedArray<u8>(fullLength);
-  auto key = keyBuf.get();
+  auto keyBuf = utils::JumpScopedArray<u8>(fullLength);
+  auto key = keyBuf->get();
   copyFullKey(srcSlot, key);
   dst->storeKeyValue(dstSlot, Slice(key, fullLength), Value(srcSlot));
 }
@@ -410,8 +410,8 @@ void BTreeNode::split(ExclusiveGuardedBufferFrame<BTreeNode>& xGuardedParent,
 
   xGuardedLeft->setFences(GetLowerFence(), Slice(sepKey, sepLength));
 
-  auto tmpNodeBuf = utils::ScopedArray<u8>(BTreeNode::Size());
-  auto nodeRight = BTreeNode::Init(tmpNodeBuf.get(), mIsLeaf);
+  auto tmpNodeBuf = utils::JumpScopedArray<u8>(BTreeNode::Size());
+  auto nodeRight = BTreeNode::Init(tmpNodeBuf->get(), mIsLeaf);
 
   nodeRight->setFences(Slice(sepKey, sepLength), GetUpperFence());
   auto swip = xGuardedLeft.swip();

--- a/source/storage/btree/core/BTreeNode.hpp
+++ b/source/storage/btree/core/BTreeNode.hpp
@@ -258,8 +258,8 @@ public:
     const u16 old_total_length = keySizeWithoutPrefix + ValSize(slot_id);
     const u16 new_total_length = keySizeWithoutPrefix + new_payload_length;
     // Allocate a block that will be freed when the calling function exits.
-    auto keyBuf = utils::ScopedArray<u8>(keySizeWithoutPrefix);
-    auto key = keyBuf.get();
+    auto keyBuf = utils::JumpScopedArray<u8>(keySizeWithoutPrefix);
+    auto key = keyBuf->get();
     std::memcpy(key, KeyDataWithoutPrefix(slot_id), keySizeWithoutPrefix);
     mSpaceUsed -= old_total_length;
     if (mDataOffset == slot[slot_id].offset && 0) {

--- a/source/utils/JumpMU.hpp
+++ b/source/utils/JumpMU.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <setjmp.h>
 #include <signal.h>
 

--- a/source/utils/Misc.cpp
+++ b/source/utils/Misc.cpp
@@ -1,21 +1,22 @@
 #include "Misc.hpp"
+
 #include "Exceptions.hpp"
 
 #include "Config.hpp"
-// -------------------------------------------------------------------------------------
+
 #include "CRC.hpp"
-// -------------------------------------------------------------------------------------
+
 #include <execinfo.h>
 
 #include <atomic>
-// -------------------------------------------------------------------------------------
+
 namespace leanstore {
 namespace utils {
-// -------------------------------------------------------------------------------------
+
 u32 getBitsNeeded(u64 input) {
   return std::max(std::floor(std::log2(input)) + 1, 1.0);
 }
-// -------------------------------------------------------------------------------------
+
 double calculateMTPS(std::chrono::high_resolution_clock::time_point begin,
                      std::chrono::high_resolution_clock::time_point end,
                      u64 factor) {

--- a/source/utils/Misc.hpp
+++ b/source/utils/Misc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "JumpMU.hpp"
 #include "Units.hpp"
 
 #include "Config.hpp"
@@ -98,6 +99,11 @@ inline u64 unfold(const u8* input, s64& x) {
 
 template <typename T> std::unique_ptr<T[]> ScopedArray(size_t size) {
   return std::move(std::make_unique<T[]>(size));
+}
+
+template <typename T>
+JumpScoped<std::unique_ptr<T[]>> JumpScopedArray(size_t size) {
+  return JumpScoped<std::unique_ptr<T[]>>(ScopedArray<T>(size));
 }
 
 template <size_t Alignment = 512> class AlignedBuffer {


### PR DESCRIPTION
need to use JumpScopedArray to free the allocated memory when longjump happens.