### PR TITLE
chore: add long-running transaction test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 # LeanStore
 
 [LeanStore](https://db.in.tum.de/~leis/papers/leanstore.pdf) is a
-high-performance OLTP storage engine optimized for many-core CPUs and NVMe SSDs.
-Our goal is to achieve performance comparable to in-memory systems when the data
-set fits into RAM, while being able to fully exploit the bandwidth of fast NVMe
-SSDs for large data sets. While LeanStore is currently a research prototype, we
-hope to make it usable in production in the future.
+high-performance storage engine optimized for many-core CPUs and NVMe SSDs.
+It's goal is to achieve performance comparable to in-memory systems when the
+data set fits into RAM, while being able to fully exploit the bandwidth of fast
+NVMe SSDs for large data sets.
 
 <div align='center'>
 <img align="center" height='500' src="./docs/images/Architecture.jpg" />
@@ -25,7 +24,7 @@ be built from the Dockerfile defined in
 
 ```sh
 # build and test
-cmake --preset debug
+cmake --preset default
 cmake --build build/debug -j `nproc`
 ctest --test-dir build/debug -j `nproc`
 ```

--- a/benchmarks/ycsb/deterministic.cpp
+++ b/benchmarks/ycsb/deterministic.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
   // -------------------------------------------------------------------------------------
   leanstore::IsolationLevel isolation_level =
       leanstore::ParseIsolationLevel(FLAGS_isolation_level);
-  const TxMode tx_type = TxMode::kOLTP;
+  const TxMode tx_type = TxMode::kShortRunning;
   // -------------------------------------------------------------------------------------
   const u64 ycsb_tuple_count =
       (FLAGS_ycsb_tuple_count)

--- a/benchmarks/ycsb/ycsb.cpp
+++ b/benchmarks/ycsb/ycsb.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
   // db.registerConfigEntry("ycsb_ops_per_tx", FLAGS_ycsb_ops_per_tx);
 
   auto isolationLevel = leanstore::ParseIsolationLevel(FLAGS_isolation_level);
-  const TxMode txType = TxMode::kOLTP;
+  const TxMode txType = TxMode::kShortRunning;
 
   const u64 ycsb_tuple_count =
       (FLAGS_ycsb_tuple_count)
@@ -194,9 +194,9 @@ int main(int argc, char** argv) {
   }
 
   if (FLAGS_ycsb_sleepy_thread) {
-    const leanstore::TxMode tx_type = FLAGS_enable_olap_mode
-                                          ? leanstore::TxMode::kOLAP
-                                          : leanstore::TxMode::kOLTP;
+    const leanstore::TxMode tx_type = FLAGS_enable_long_running_transaction
+                                          ? leanstore::TxMode::kLongRunning
+                                          : leanstore::TxMode::kShortRunning;
     crm.scheduleJobAsync(exec_threads - 1, [&]() {
       running_threads_counter++;
       while (keep_running) {

--- a/source/Config.cpp
+++ b/source/Config.cpp
@@ -22,10 +22,10 @@ DEFINE_string(data_dir, "~/.leanstore",
 DEFINE_uint64(db_file_capacity, 1825361100800,
               "DB file capacity (bytes)"); // 1700 GB
 
-// Config for multi-version, OLAP-isolated BTree
+// Config for TransactionKV
 DEFINE_bool(enable_fat_tuple, false, "");
-DEFINE_bool(enable_olap_mode, true,
-            "Use OLAP mode for long running transactions");
+DEFINE_bool(enable_long_running_transaction, true,
+            "For long running transactions");
 
 DEFINE_uint32(db_file_prealloc_gib, 0, "Disk size to pre-allocate on DB file");
 DEFINE_bool(recover, false, "");

--- a/source/Config.hpp
+++ b/source/Config.hpp
@@ -10,9 +10,9 @@ DECLARE_uint64(buffer_pool_size);
 DECLARE_string(data_dir);
 DECLARE_uint64(db_file_capacity);
 
-// Config for multi-version, OLAP-isolated BTree
+// Config for TransactionKV
 DECLARE_bool(enable_fat_tuple);
-DECLARE_bool(enable_olap_mode);
+DECLARE_bool(enable_long_running_transaction);
 
 DECLARE_uint32(worker_threads);
 DECLARE_bool(cpu_counters);

--- a/source/LeanStore.cpp
+++ b/source/LeanStore.cpp
@@ -73,7 +73,8 @@ LeanStore::LeanStore() {
     DeSerializeFlags();
   }
   if (!FLAGS_wal) {
-    LOG(FATAL) << "TransactionKV is not enabled without WAL, please enable FLAGS_wal";
+    LOG(FATAL)
+        << "TransactionKV is not enabled without WAL, please enable FLAGS_wal";
   }
 
   // open file
@@ -288,7 +289,8 @@ void LeanStore::startProfilingThread() {
       }
 
       const u64 tx = std::stoull(cr_table.get("0", "tx"));
-      const u64 olap_tx = std::stoull(cr_table.get("0", "olap_tx"));
+      const u64 long_running_tx =
+          std::stoull(cr_table.get("0", "long_running_tx"));
       const double tx_abort = std::stod(cr_table.get("0", "tx_abort"));
       const double tx_abort_pct = tx_abort * 100.0 / (tx_abort + tx);
       const double rfa_pct =
@@ -304,23 +306,23 @@ void LeanStore::startProfilingThread() {
       // using RowType = std::vector<variant<std::string, const char*, Table>>;
       if (FLAGS_print_tx_console) {
         tabulate::Table table;
-        table.add_row({"t", "OLTP TX", "RF %", "Abort%", "OLAP TX", "W MiB",
-                       "R MiB", "Instrs/TX", "Cycles/TX", "CPUs", "L1/TX",
-                       "LLC/TX", "GHz", "WAL GiB/s", "GCT GiB/s", "Space G",
-                       "GCT Rounds"});
-        table.add_row({std::to_string(seconds), std::to_string(tx),
-                       std::to_string(remote_flushes_pct),
-                       std::to_string(tx_abort_pct), std::to_string(olap_tx),
-                       bm_table.get("0", "w_mib"), bm_table.get("0", "r_mib"),
-                       std::to_string(instr_per_tx),
-                       std::to_string(cycles_per_tx),
-                       std::to_string(cpu_table.workers_agg_events["CPU"]),
-                       std::to_string(l1_per_tx), std::to_string(llc_per_tx),
-                       std::to_string(cpu_table.workers_agg_events["GHz"]),
-                       cr_table.get("0", "wal_write_gib"),
-                       cr_table.get("0", "gct_write_gib"),
-                       bm_table.get("0", "space_usage_gib"),
-                       cr_table.get("0", "gct_rounds")});
+        table.add_row({"t", "ShortRunning TX", "RF %", "Abort%",
+                       "LongRunning TX", "W MiB", "R MiB", "Instrs/TX",
+                       "Cycles/TX", "CPUs", "L1/TX", "LLC/TX", "GHz",
+                       "WAL GiB/s", "GCT GiB/s", "Space G", "GCT Rounds"});
+        table.add_row(
+            {std::to_string(seconds), std::to_string(tx),
+             std::to_string(remote_flushes_pct), std::to_string(tx_abort_pct),
+             std::to_string(long_running_tx), bm_table.get("0", "w_mib"),
+             bm_table.get("0", "r_mib"), std::to_string(instr_per_tx),
+             std::to_string(cycles_per_tx),
+             std::to_string(cpu_table.workers_agg_events["CPU"]),
+             std::to_string(l1_per_tx), std::to_string(llc_per_tx),
+             std::to_string(cpu_table.workers_agg_events["GHz"]),
+             cr_table.get("0", "wal_write_gib"),
+             cr_table.get("0", "gct_write_gib"),
+             bm_table.get("0", "space_usage_gib"),
+             cr_table.get("0", "gct_rounds")});
 
         table.format().width(10);
         table.column(0).format().width(5);

--- a/source/concurrency-recovery/HistoryTree.hpp
+++ b/source/concurrency-recovery/HistoryTree.hpp
@@ -53,14 +53,14 @@ public:
       WORKERID workerId, TXID txId, COMMANDID commandId, const bool isRemove,
       std::function<void(const u8*, u64 payloadLength)> cb) override;
 
-  virtual void PurgeVersions(WORKERID workerId, TXID from_tx_id, TXID to_tx_id,
+  virtual void PurgeVersions(WORKERID workerId, TXID fromTxId, TXID toTxId,
                              RemoveVersionCallback cb,
                              const u64 limit) override;
 
   // [from, to]
-  virtual void VisitRemovedVersions(WORKERID workerId, TXID from_tx_id,
-                                   TXID to_tx_id,
-                                   RemoveVersionCallback cb) override;
+  virtual void VisitRemovedVersions(WORKERID workerId, TXID fromTxId,
+                                    TXID toTxId,
+                                    RemoveVersionCallback cb) override;
 };
 
 } // namespace cr

--- a/source/concurrency-recovery/HistoryTreeInterface.hpp
+++ b/source/concurrency-recovery/HistoryTreeInterface.hpp
@@ -23,12 +23,13 @@ public:
       WORKERID workerId, TXID txId, COMMANDID commandId, const bool isRemove,
       std::function<void(const u8*, u64 payloadSize)> cb) = 0;
 
-  virtual void PurgeVersions(WORKERID workerId, TXID from_tx_id, TXID to_tx_id,
+  // represents the range of [from, to], both inclusive
+  virtual void PurgeVersions(WORKERID workerId, TXID fromTxId, TXID toTxId,
                              RemoveVersionCallback cb, const u64 limit = 0) = 0;
 
-  virtual void VisitRemovedVersions(WORKERID workerId, TXID from_tx_id,
-                                   TXID to_tx_id,
-                                   RemoveVersionCallback cb) = 0; // [from, to]
+  // represents the range of [from, to], both inclusive
+  virtual void VisitRemovedVersions(WORKERID workerId, TXID fromTxId,
+                                    TXID toTxId, RemoveVersionCallback cb) = 0;
 };
 
 } // namespace cr

--- a/source/concurrency-recovery/Transaction.hpp
+++ b/source/concurrency-recovery/Transaction.hpp
@@ -8,19 +8,19 @@
 namespace leanstore {
 
 enum class TxMode : u8 {
-  kOLAP = 0,
-  kOLTP = 1,
+  kLongRunning = 0,
+  kShortRunning = 1,
   kDeterministic = 2,
   kInstantlyVisibleBulkInsert = 3,
 };
 
 inline std::string ToString(TxMode txMode) {
   switch (txMode) {
-  case TxMode::kOLAP: {
-    return "OLAP";
+  case TxMode::kLongRunning: {
+    return "LongRunning";
   }
-  case TxMode::kOLTP: {
-    return "OLTP";
+  case TxMode::kShortRunning: {
+    return "ShortRunning";
   }
   case TxMode::kDeterministic: {
     return "Deterministic";
@@ -93,7 +93,7 @@ public:
   LID mMaxObservedGSN = 0;
 
   /// mTxMode is the mode of the current transaction.
-  TxMode mTxMode = TxMode::kOLTP;
+  TxMode mTxMode = TxMode::kShortRunning;
 
   /// mTxIsolationLevel is the isolation level for the current transaction.
   IsolationLevel mTxIsolationLevel = IsolationLevel::kSnapshotIsolation;
@@ -113,12 +113,12 @@ public:
   bool mWalExceedBuffer = false;
 
 public:
-  inline bool IsOLAP() {
-    return mTxMode == TxMode::kOLAP;
+  inline bool IsLongRunning() {
+    return mTxMode == TxMode::kLongRunning;
   }
 
   inline bool IsOLTP() {
-    return mTxMode == TxMode::kOLTP;
+    return mTxMode == TxMode::kShortRunning;
   }
 
   inline bool AtLeastSI() {

--- a/source/concurrency-recovery/Worker.cpp
+++ b/source/concurrency-recovery/Worker.cpp
@@ -96,9 +96,9 @@ void Worker::StartTx(TxMode mode, IsolationLevel level, bool isReadOnly) {
   mLogging.mTxReadSnapshot = Logging::sGlobalMinFlushedGSN.load();
   mLogging.mHasRemoteDependency = false;
 
-  // Draw TXID from global counter and publish it with the TX type (i.e., OLAP
-  // or OLTP) We have to acquire a transaction id and use it for locking in ANY
-  // isolation level
+  // Draw TXID from global counter and publish it with the TX type (i.e.
+  // long-running or short-running) We have to acquire a transaction id and use
+  // it for locking in ANY isolation level
   if (level >= IsolationLevel::kSnapshotIsolation) {
     {
       utils::Timer timer(CRCounters::MyCounters().cc_ms_snapshotting);
@@ -107,9 +107,9 @@ void Worker::StartTx(TxMode mode, IsolationLevel level, bool isReadOnly) {
                               std::memory_order_release);
 
       mActiveTx.mStartTs = ConcurrencyControl::sGlobalClock.fetch_add(1);
-      if (FLAGS_enable_olap_mode) {
+      if (FLAGS_enable_long_running_transaction) {
         curWorkerSnapshot.store(mActiveTx.mStartTs |
-                                    ((mActiveTx.IsOLAP()) ? kOlapBit : 0),
+                                    ((mActiveTx.IsLongRunning()) ? kOlapBit : 0),
                                 std::memory_order_release);
       } else {
         curWorkerSnapshot.store(mActiveTx.mStartTs, std::memory_order_release);

--- a/source/concurrency-recovery/Worker.hpp
+++ b/source/concurrency-recovery/Worker.hpp
@@ -339,7 +339,7 @@ public:
     return mActiveTx.mState == TxState::kStarted;
   }
 
-  void StartTx(TxMode mode = TxMode::kOLTP,
+  void StartTx(TxMode mode = TxMode::kShortRunning,
                IsolationLevel level = IsolationLevel::kSnapshotIsolation,
                bool isReadOnly = false);
 

--- a/source/profiling/counters/WorkerCounters.hpp
+++ b/source/profiling/counters/WorkerCounters.hpp
@@ -24,7 +24,7 @@ struct WorkerCounters {
   std::atomic<u64> allocate_operations_counter = 0;
   std::atomic<u64> mNumContentions = 0;
   std::atomic<u64> tx = 0;
-  std::atomic<u64> olap_tx = 0;
+  std::atomic<u64> long_running_tx = 0;
   std::atomic<u64> olap_scanned_tuples = 0;
   std::atomic<u64> tx_abort = 0;
   std::atomic<u64> olap_tx_abort = 0;

--- a/source/profiling/tables/CRTable.cpp
+++ b/source/profiling/tables/CRTable.cpp
@@ -36,8 +36,8 @@ void CRTable::open() {
   columns.emplace("tx_abort", [](Column& col) {
     col << Sum(WorkerCounters::sCounters, &WorkerCounters::tx_abort);
   });
-  columns.emplace("olap_tx", [](Column& col) {
-    col << Sum(WorkerCounters::sCounters, &WorkerCounters::olap_tx);
+  columns.emplace("long_running_tx", [](Column& col) {
+    col << Sum(WorkerCounters::sCounters, &WorkerCounters::long_running_tx);
   });
   columns.emplace("olap_scanned_tuples", [](Column& col) {
     col << Sum(WorkerCounters::sCounters, &WorkerCounters::olap_scanned_tuples);

--- a/source/profiling/tables/ConfigsTable.cpp
+++ b/source/profiling/tables/ConfigsTable.cpp
@@ -72,8 +72,9 @@ void ConfigsTable::open() {
   columns.emplace("c_pgc", [&](Column& col) { col << FLAGS_pgc; });
   columns.emplace("c_isolation_level",
                   [&](Column& col) { col << FLAGS_isolation_level; });
-  columns.emplace("c_olap_mode",
-                  [&](Column& col) { col << FLAGS_enable_olap_mode; });
+  columns.emplace("c_enable_long_running_transaction", [&](Column& col) {
+    col << FLAGS_enable_long_running_transaction;
+  });
   columns.emplace("c_history_tree_inserts",
                   [&](Column& col) { col << FLAGS_history_tree_inserts; });
 

--- a/source/storage/btree/ChainedTuple.hpp
+++ b/source/storage/btree/ChainedTuple.hpp
@@ -19,7 +19,7 @@ public:
 
   u16 mOldestTx = 0;
 
-  u8 mIsRemoved = 1;
+  u8 mIsTombstone = 1;
 
   // latest version in-place
   u8 mPayload[];
@@ -31,13 +31,13 @@ public:
   /// usually called by a placmenet new operator.
   ChainedTuple(WORKERID workerId, TXID txId, Slice val)
       : Tuple(TupleFormat::kChained, workerId, txId),
-        mIsRemoved(false) {
+        mIsTombstone(false) {
     std::memcpy(mPayload, val.data(), val.size());
   }
 
   ChainedTuple(WORKERID workerId, TXID txId, COMMANDID commandId, Slice val)
       : Tuple(TupleFormat::kChained, workerId, txId, commandId),
-        mIsRemoved(false) {
+        mIsTombstone(false) {
     std::memcpy(mPayload, val.data(), val.size());
   }
 
@@ -50,7 +50,7 @@ public:
   ChainedTuple(FatTuple& oldFatTuple)
       : Tuple(TupleFormat::kChained, oldFatTuple.mWorkerId, oldFatTuple.mTxId,
               oldFatTuple.mCommandId),
-        mIsRemoved(false) {
+        mIsTombstone(false) {
     std::memmove(mPayload, oldFatTuple.mPayload, oldFatTuple.mValSize);
   }
 
@@ -99,7 +99,7 @@ public:
 inline std::tuple<OpCode, u16> ChainedTuple::GetVisibleTuple(
     Slice payload, ValCallback callback) const {
   if (cr::Worker::my().cc.VisibleForMe(mWorkerId, mTxId)) {
-    if (mIsRemoved) {
+    if (mIsTombstone) {
       return {OpCode::kNotFound, 1};
     }
 

--- a/source/storage/btree/TransactionKV.hpp
+++ b/source/storage/btree/TransactionKV.hpp
@@ -27,8 +27,7 @@ namespace leanstore::storage::btree {
 // Missing points: FatTuple::remove, garbage leaves can escape from us
 class TransactionKV : public BasicKV {
 public:
-  /// Graveyard to store removed tuples for long-running transactions, e.g. OLAP
-  /// transactions.
+  /// Graveyard to store removed tuples for long-running transactions.
   BasicKV* mGraveyard;
 
   TransactionKV() {
@@ -36,402 +35,41 @@ public:
   }
 
 public:
-  //---------------------------------------------------------------------------
-  // KV Interfaces
-  //---------------------------------------------------------------------------
-  virtual OpCode Lookup(Slice key, ValCallback valCallback) override;
+  OpCode Lookup(Slice key, ValCallback valCallback) override;
 
-  virtual OpCode Insert(Slice key, Slice val) override;
+  OpCode ScanAsc(Slice startKey, ScanCallback) override;
 
-  virtual OpCode UpdatePartial(Slice key, MutValCallback updateCallBack,
-                               UpdateDesc& updateDesc) override;
+  OpCode ScanDesc(Slice startKey, ScanCallback) override;
 
-  virtual OpCode Remove(Slice key) override;
+  OpCode Insert(Slice key, Slice val) override;
 
-  virtual OpCode ScanAsc(Slice startKey, ScanCallback) override;
+  OpCode UpdatePartial(Slice key, MutValCallback updateCallBack,
+                       UpdateDesc& updateDesc) override;
 
-  virtual OpCode ScanDesc(Slice startKey, ScanCallback) override;
+  OpCode Remove(Slice key) override;
 
-public:
-  //---------------------------------------------------------------------------
-  // Object Utils
-  //---------------------------------------------------------------------------
   void Init(TREEID treeId, Config config, BasicKV* graveyard) {
     this->mGraveyard = graveyard;
     BasicKV::Init(treeId, config);
   }
 
-  virtual SpaceCheckResult checkSpaceUtilization(BufferFrame& bf) override {
-    if (!FLAGS_xmerge) {
-      return SpaceCheckResult::kNothing;
-    }
-
-    HybridGuard bfGuard(&bf.header.mLatch);
-    bfGuard.toOptimisticOrJump();
-    if (bf.page.mBTreeId != mTreeId) {
-      jumpmu::Jump();
-    }
-
-    GuardedBufferFrame<BTreeNode> guardedNode(std::move(bfGuard), &bf);
-    if (!guardedNode->mIsLeaf ||
-        !triggerPageWiseGarbageCollection(guardedNode)) {
-      return BTreeGeneric::checkSpaceUtilization(bf);
-    }
-
-    guardedNode.ToExclusiveMayJump();
-    guardedNode.SyncGSNBeforeWrite();
-
-    for (u16 i = 0; i < guardedNode->mNumSeps; i++) {
-      auto& tuple = *Tuple::From(guardedNode->ValData(i));
-      if (tuple.mFormat == TupleFormat::kFat) {
-        auto& fatTuple = *FatTuple::From(guardedNode->ValData(i));
-        const u32 newLength = fatTuple.mValSize + sizeof(ChainedTuple);
-        fatTuple.ConvertToChained(mTreeId);
-        DCHECK(newLength < guardedNode->ValSize(i));
-        guardedNode->shortenPayload(i, newLength);
-        DCHECK(tuple.mFormat == TupleFormat::kChained);
-      }
-    }
-    guardedNode->mHasGarbage = false;
-    guardedNode.unlock();
-
-    const SpaceCheckResult result = BTreeGeneric::checkSpaceUtilization(bf);
-    if (result == SpaceCheckResult::kPickAnotherBf) {
-      return SpaceCheckResult::kPickAnotherBf;
-    }
-    return SpaceCheckResult::kRestartSameBf;
-  }
+  SpaceCheckResult checkSpaceUtilization(BufferFrame& bf) override;
 
   // This undo implementation works only for rollback and not for undo
   // operations during recovery
   void undo(const u8* walEntryPtr, const u64) override;
 
-  virtual void todo(const u8* entryPtr, const u64 versionWorkerId,
-                    const u64 versionTxId, const bool calledBefore) override {
-    // Only point-gc and for removed tuples
-    const auto& version = *reinterpret_cast<const RemoveVersion*>(entryPtr);
-    if (version.mTxId < cr::Worker::my().cc.local_all_lwm) {
-      DCHECK(version.mDanglingPointer.mBf != nullptr);
-      // Optimistic fast path
-      JUMPMU_TRY() {
-        BTreeExclusiveIterator xIter(
-            *static_cast<BTreeGeneric*>(this), version.mDanglingPointer.mBf,
-            version.mDanglingPointer.mLatchVersionShouldBe);
-        auto& node = xIter.mGuardedLeaf;
-        auto& chainedTuple = *ChainedTuple::From(
-            node->ValData(version.mDanglingPointer.mHeadSlot));
-        // Being chained is implicit because we check for version, so the state
-        // can not be changed after staging the todo
-        ENSURE(chainedTuple.mFormat == TupleFormat::kChained &&
-               !chainedTuple.IsWriteLocked() &&
-               chainedTuple.mWorkerId == versionWorkerId &&
-               chainedTuple.mTxId == versionTxId && chainedTuple.mIsRemoved);
-        node->removeSlot(version.mDanglingPointer.mHeadSlot);
-        xIter.MarkAsDirty();
-        xIter.TryMergeIfNeeded();
-        JUMPMU_RETURN;
-      }
-      JUMPMU_CATCH() {
-      }
-    }
-    auto key = version.RemovedKey();
-    OpCode ret;
-    if (calledBefore) {
-      // Delete from mGraveyard
-      // ENSURE(version_tx_id < cr::Worker::my().local_all_lwm);
-      JUMPMU_TRY() {
-        BTreeExclusiveIterator xIter(*static_cast<BTreeGeneric*>(mGraveyard));
-        if (xIter.SeekExact(key)) {
-          ret = xIter.RemoveCurrent();
-          ENSURE(ret == OpCode::kOK);
-          xIter.MarkAsDirty();
-        } else {
-          UNREACHABLE();
-        }
-      }
-      JUMPMU_CATCH() {
-      }
-      return;
-    }
-    // TODO: Corner cases if the tuple got inserted after a remove
-    JUMPMU_TRY() {
-      BTreeExclusiveIterator xIter(*static_cast<BTreeGeneric*>(this));
-      if (!xIter.SeekExact(key)) {
-        JUMPMU_RETURN; // TODO:
-      }
-      // ENSURE(ret == OpCode::kOK);
-      MutableSlice mutRawVal = xIter.MutableVal();
-      // Checks
-      auto& tuple = *Tuple::From(mutRawVal.Data());
-      if (tuple.mFormat == TupleFormat::kFat) {
-        JUMPMU_RETURN;
-      }
-      ChainedTuple& chainedTuple = *ChainedTuple::From(mutRawVal.Data());
-      if (!chainedTuple.IsWriteLocked()) {
-        if (chainedTuple.mWorkerId == versionWorkerId &&
-            chainedTuple.mTxId == versionTxId && chainedTuple.mIsRemoved) {
-          if (chainedTuple.mTxId < cr::Worker::my().cc.local_all_lwm) {
-            ret = xIter.RemoveCurrent();
-            xIter.MarkAsDirty();
-            ENSURE(ret == OpCode::kOK);
-            xIter.TryMergeIfNeeded();
-            COUNTERS_BLOCK() {
-              WorkerCounters::MyCounters().cc_todo_removed[mTreeId]++;
-            }
-          } else if (chainedTuple.mTxId < cr::Worker::my().cc.local_oltp_lwm) {
-            // Move to mGraveyard
-            {
-              BTreeExclusiveIterator graveyardXIter(
-                  *static_cast<BTreeGeneric*>(mGraveyard));
-              OpCode g_ret = graveyardXIter.InsertKV(key, xIter.value());
-              ENSURE(g_ret == OpCode::kOK);
-              graveyardXIter.MarkAsDirty();
-            }
-            ret = xIter.RemoveCurrent();
-            ENSURE(ret == OpCode::kOK);
-            xIter.MarkAsDirty();
-            xIter.TryMergeIfNeeded();
-            COUNTERS_BLOCK() {
-              WorkerCounters::MyCounters().cc_todo_moved_gy[mTreeId]++;
-            }
-          } else {
-            UNREACHABLE();
-          }
-        }
-      }
-    }
-    JUMPMU_CATCH() {
-      UNREACHABLE();
-    }
-  }
+  void todo(const u8* entryPtr, const u64 versionWorkerId,
+            const u64 versionTxId, const bool calledBefore) override;
 
-  virtual void unlock(const u8* walEntryPtr) override {
-    const WALPayload& entry = *reinterpret_cast<const WALPayload*>(walEntryPtr);
-    Slice key;
-    switch (entry.mType) {
-    case WALPayload::TYPE::WALTxInsert: {
-      // Assuming no insert after remove
-      auto& walInsert = *reinterpret_cast<const WALTxInsert*>(&entry);
-      key = walInsert.GetKey();
-      break;
-    }
-    case WALPayload::TYPE::WALTxUpdate: {
-      auto& walUpdate = *reinterpret_cast<const WALTxUpdate*>(&entry);
-      key = walUpdate.GetKey();
-      break;
-    }
-    case WALPayload::TYPE::WALTxRemove: {
-      auto& removeEntry = *reinterpret_cast<const WALTxRemove*>(&entry);
-      key = removeEntry.RemovedKey();
-      break;
-    }
-    default: {
-      return;
-      break;
-    }
-    }
-
-    JUMPMU_TRY() {
-      BTreeExclusiveIterator xIter(*static_cast<BTreeGeneric*>(this));
-      auto succeed = xIter.SeekExact(key);
-      DCHECK(succeed) << "Can not find key in the BTree"
-                      << ", key=" << std::string((char*)key.data(), key.size());
-      auto& tuple = *Tuple::From(xIter.MutableVal().Data());
-      ENSURE(tuple.mFormat == TupleFormat::kChained);
-      /**
-       * The major work is in traversing the tree:
-       *
-       * if (tuple.mTxId == cr::ActiveTx().mStartTs &&
-       *     tuple.mWorkerId == cr::Worker::my().mWorkerId) {
-       *   auto& chainedTuple =
-       *       *reinterpret_cast<ChainedTuple*>(xIter.MutableVal().data());
-       *   chainedTuple.mCommitTs = cr::ActiveTx().mCommitTs | kMsb;
-       * }
-       */
-    }
-    JUMPMU_CATCH() {
-      UNREACHABLE();
-    }
-  }
+  void unlock(const u8* walEntryPtr) override;
 
 private:
-  template <bool asc = true> OpCode scan(Slice key, ScanCallback callback) {
-    // TODO: index range lock for serializability
-    COUNTERS_BLOCK() {
-      if (asc) {
-        WorkerCounters::MyCounters().dt_scan_asc[mTreeId]++;
-      } else {
-        WorkerCounters::MyCounters().dt_scan_desc[mTreeId]++;
-      }
-    }
+  template <bool asc = true>
+  OpCode scan4ShortRunningTx(Slice key, ScanCallback callback);
 
-    bool keepScanning = true;
-    JUMPMU_TRY() {
-      BTreeSharedIterator iter(*static_cast<BTreeGeneric*>(this),
-                               LatchMode::kShared);
-
-      bool succeed = asc ? iter.Seek(key) : iter.SeekForPrev(key);
-      while (succeed) {
-        iter.AssembleKey();
-        Slice scannedKey = iter.key();
-        // auto reconstruct = GetVisibleTuple(iter.value(), [&](Slice
-        // scannedVal) {
-        auto [opCode, versionsRead] =
-            GetVisibleTuple(iter.value(), [&](Slice scannedVal) {
-              COUNTERS_BLOCK() {
-                WorkerCounters::MyCounters().dt_scan_callback[mTreeId] +=
-                    cr::ActiveTx().IsOLAP();
-              }
-              keepScanning = callback(scannedKey, scannedVal);
-            });
-        COUNTERS_BLOCK() {
-          WorkerCounters::MyCounters().cc_read_chains[mTreeId]++;
-          WorkerCounters::MyCounters().cc_read_versions_visited[mTreeId] +=
-              versionsRead;
-          if (opCode != OpCode::kOK) {
-            WorkerCounters::MyCounters().cc_read_chains_not_found[mTreeId]++;
-            WorkerCounters::MyCounters()
-                .cc_read_versions_visited_not_found[mTreeId] += versionsRead;
-          }
-        }
-        if (!keepScanning) {
-          JUMPMU_RETURN OpCode::kOK;
-        }
-
-        succeed = asc ? iter.Next() : iter.Prev();
-      }
-      JUMPMU_RETURN OpCode::kOK;
-    }
-    JUMPMU_CATCH() {
-      ENSURE(false);
-    }
-    UNREACHABLE();
-    JUMPMU_RETURN OpCode::kOther;
-  }
-
-  // TODO: atm, only ascending
-  template <bool asc = true> OpCode scanOLAP(Slice key, ScanCallback callback) {
-    volatile bool keepScanning = true;
-
-    JUMPMU_TRY() {
-      BTreeSharedIterator iter(*static_cast<BTreeGeneric*>(this));
-      OpCode o_ret;
-
-      BTreeSharedIterator graveyardIter(
-          *static_cast<BTreeGeneric*>(mGraveyard));
-      OpCode g_ret;
-      Slice graveyardLowerBound, graveyardUpperBound;
-      graveyardLowerBound = key;
-
-      if (!iter.Seek(key)) {
-        JUMPMU_RETURN OpCode::kOK;
-      }
-      o_ret = OpCode::kOK;
-      iter.AssembleKey();
-
-      // Now it begins
-      graveyardUpperBound = Slice(iter.mGuardedLeaf->getUpperFenceKey(),
-                                  iter.mGuardedLeaf->mUpperFence.length);
-      auto g_range = [&]() {
-        graveyardIter.Reset();
-        if (mGraveyard->IsRangeEmpty(graveyardLowerBound,
-                                     graveyardUpperBound)) {
-          g_ret = OpCode::kOther;
-          return;
-        }
-        if (!graveyardIter.Seek(graveyardLowerBound)) {
-          g_ret = OpCode::kNotFound;
-          return;
-        }
-
-        graveyardIter.AssembleKey();
-        if (graveyardIter.key() > graveyardUpperBound) {
-          g_ret = OpCode::kOther;
-          graveyardIter.Reset();
-          return;
-        }
-
-        g_ret = OpCode::kOK;
-      };
-
-      g_range();
-      auto take_from_oltp = [&]() {
-        GetVisibleTuple(iter.value(), [&](Slice value) {
-          COUNTERS_BLOCK() {
-            WorkerCounters::MyCounters().dt_scan_callback[mTreeId] +=
-                cr::ActiveTx().IsOLAP();
-          }
-          keepScanning = callback(iter.key(), value);
-        });
-        if (!keepScanning) {
-          return false;
-        }
-        const bool is_last_one = iter.IsLastOne();
-        if (is_last_one) {
-          graveyardIter.Reset();
-        }
-        o_ret = iter.Next() ? OpCode::kOK : OpCode::kNotFound;
-        if (is_last_one) {
-          graveyardLowerBound = Slice(&iter.mBuffer[0], iter.mFenceSize + 1);
-          graveyardUpperBound = Slice(iter.mGuardedLeaf->getUpperFenceKey(),
-                                      iter.mGuardedLeaf->mUpperFence.length);
-          g_range();
-        }
-        return true;
-      };
-      while (true) {
-        if (g_ret != OpCode::kOK && o_ret == OpCode::kOK) {
-          iter.AssembleKey();
-          if (!take_from_oltp()) {
-            JUMPMU_RETURN OpCode::kOK;
-          }
-        } else if (g_ret == OpCode::kOK && o_ret != OpCode::kOK) {
-          graveyardIter.AssembleKey();
-          Slice g_key = graveyardIter.key();
-          GetVisibleTuple(graveyardIter.value(), [&](Slice value) {
-            COUNTERS_BLOCK() {
-              WorkerCounters::MyCounters().dt_scan_callback[mTreeId] +=
-                  cr::ActiveTx().IsOLAP();
-            }
-            keepScanning = callback(g_key, value);
-          });
-          if (!keepScanning) {
-            JUMPMU_RETURN OpCode::kOK;
-          }
-          g_ret = graveyardIter.Next() ? OpCode::kOK : OpCode::kNotFound;
-        } else if (g_ret == OpCode::kOK && o_ret == OpCode::kOK) {
-          iter.AssembleKey();
-          graveyardIter.AssembleKey();
-          Slice g_key = graveyardIter.key();
-          Slice oltp_key = iter.key();
-          if (oltp_key <= g_key) {
-            if (!take_from_oltp()) {
-              JUMPMU_RETURN OpCode::kOK;
-            }
-          } else {
-            GetVisibleTuple(graveyardIter.value(), [&](Slice value) {
-              COUNTERS_BLOCK() {
-                WorkerCounters::MyCounters().dt_scan_callback[mTreeId] +=
-                    cr::ActiveTx().IsOLAP();
-              }
-              keepScanning = callback(g_key, value);
-            });
-            if (!keepScanning) {
-              JUMPMU_RETURN OpCode::kOK;
-            }
-            g_ret = graveyardIter.Next() ? OpCode::kOK : OpCode::kNotFound;
-          }
-        } else {
-          JUMPMU_RETURN OpCode::kOK;
-        }
-      }
-    }
-    JUMPMU_CATCH() {
-      ENSURE(false);
-    }
-    UNREACHABLE();
-    JUMPMU_RETURN OpCode::kOther;
-  }
+  template <bool asc = true>
+  OpCode scan4LongRunningTx(Slice key, ScanCallback callback);
 
   inline bool VisibleForMe(WORKERID workerId, TXID txId) {
     return cr::Worker::my().cc.VisibleForMe(workerId, txId);

--- a/tests/AnomaliesTest.cpp
+++ b/tests/AnomaliesTest.cpp
@@ -7,8 +7,7 @@
 using namespace leanstore::utils;
 using namespace leanstore::storage::btree;
 
-namespace leanstore {
-namespace test {
+namespace leanstore::test {
 
 class AnomaliesTest : public ::testing::Test {
 protected:
@@ -325,8 +324,7 @@ TEST_F(AnomaliesTest, G2Item) {
   s2->CommitTx();
 }
 
-} // namespace test
-} // namespace leanstore
+} // namespace leanstore::test
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,12 +44,4 @@ leanstore_add_test_without_gtest_main(TransactionKVTest)
 leanstore_add_test_without_gtest_main(MVCCTest)
 leanstore_add_test_without_gtest_main(AnomaliesTest)
 leanstore_add_test_without_gtest_main(AbortTest)
-
-# # for code coverages
-# if(BUILD_WITH_COVERAGE)
-#   add_custom_target(coverage
-#       COMMAND gcovr -r . --json-pretty -json coverage.json --xml-pretty -xml coverage.xml --exclude 'build/*' --exclude 'tests/*'
-#       COMMENT "Generating code coverage reports"
-#       DEPENDS ${TEST_EXECUTABLES}
-#   )
-# endif()
+leanstore_add_test_without_gtest_main(LongRunningTxTest)

--- a/tests/LongRunningTxTest.cpp
+++ b/tests/LongRunningTxTest.cpp
@@ -1,0 +1,240 @@
+#include "KVInterface.hpp"
+#include "LeanStore.hpp"
+#include "concurrency-recovery/CRMG.hpp"
+#include "concurrency-recovery/Transaction.hpp"
+#include "concurrency-recovery/Worker.hpp"
+#include "storage/buffer-manager/BufferManager.hpp"
+#include "utils/Defer.hpp"
+#include "utils/RandomGenerator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+using namespace leanstore::utils;
+using namespace leanstore::storage::btree;
+
+namespace leanstore::test {
+
+class LongRunningTxTest : public ::testing::Test {
+protected:
+  std::string mTreeName;
+  TransactionKV* mKv;
+
+protected:
+  LongRunningTxTest() = default;
+
+  ~LongRunningTxTest() = default;
+
+  void SetUp() override {
+    // init the leanstore
+    auto* leanstore = GetLeanStore();
+
+    mTreeName = RandomGenerator::RandomAlphString(10);
+    auto config = BTreeGeneric::Config{
+        .mEnableWal = FLAGS_wal,
+        .mUseBulkInsert = FLAGS_bulk_insert,
+    };
+
+    // create a btree for test
+    cr::CRManager::sInstance->scheduleJobSync(0, [&]() {
+      cr::Worker::my().StartTx();
+      SCOPED_DEFER(cr::Worker::my().CommitTx());
+      leanstore->RegisterTransactionKV(mTreeName, config, &mKv);
+      ASSERT_NE(mKv, nullptr);
+    });
+  }
+
+  void TearDown() override {
+    cr::CRManager::sInstance->scheduleJobSync(1, [&]() {
+      cr::Worker::my().StartTx();
+      SCOPED_DEFER(cr::Worker::my().CommitTx());
+      GetLeanStore()->UnRegisterTransactionKV(mTreeName);
+    });
+  }
+
+public:
+  inline static auto CreateLeanStore() {
+    FLAGS_enable_print_btree_stats_on_exit = true;
+    FLAGS_wal = true;
+    FLAGS_bulk_insert = false;
+    FLAGS_worker_threads = 3;
+    FLAGS_recover = false;
+    FLAGS_data_dir = "/tmp/MVCCTest";
+
+    std::filesystem::path dirPath = FLAGS_data_dir;
+    std::filesystem::remove_all(dirPath);
+    std::filesystem::create_directories(dirPath);
+    return std::make_unique<leanstore::LeanStore>();
+  }
+
+  inline static leanstore::LeanStore* GetLeanStore() {
+    static auto sLeanStore = CreateLeanStore();
+    return sLeanStore.get();
+  }
+};
+
+static Slice ToSlice(const std::string& src) {
+  return Slice((const u8*)src.data(), src.size());
+}
+
+// TODO(lookup from graveyard)
+TEST_F(LongRunningTxTest, Lookup) {
+  std::string key1("1"), val1("10");
+  std::string key2("2"), val2("20");
+  std::string res;
+
+  std::string copiedVal;
+  auto copyValue = [&](Slice val) {
+    copiedVal = std::string((const char*)val.data(), val.size());
+  };
+
+  // Insert 2 key-values as the test base.
+  cr::CRManager::sInstance->scheduleJobSync(1, [&]() {
+    cr::Worker::my().StartTx();
+    SCOPED_DEFER(cr::Worker::my().CommitTx());
+    EXPECT_EQ(mKv->Insert(ToSlice(key1), ToSlice(val1)), OpCode::kOK);
+    EXPECT_EQ(mKv->Insert(ToSlice(key2), ToSlice(val2)), OpCode::kOK);
+  });
+
+  cr::CRManager::sInstance->scheduleJobSync(
+      1, [&]() { cr::Worker::my().StartTx(); });
+
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    cr::Worker::my().StartTx(TxMode::kLongRunning);
+
+    // got the old value in worker 2
+    EXPECT_EQ(mKv->Lookup(ToSlice(key1), copyValue), OpCode::kOK);
+    EXPECT_EQ(copiedVal, val1);
+
+    EXPECT_EQ(mKv->Lookup(ToSlice(key2), copyValue), OpCode::kOK);
+    EXPECT_EQ(copiedVal, val2);
+  });
+
+  // remove the key in worker 1
+  cr::CRManager::sInstance->scheduleJobSync(1, [&]() {
+    EXPECT_EQ(mKv->Remove(ToSlice(key1)), OpCode::kOK);
+    EXPECT_EQ(mKv->Remove(ToSlice(key2)), OpCode::kOK);
+  });
+
+  // got the old value in worker 2
+  cr::CRManager::sInstance->scheduleJobAsync(2, [&]() {
+    EXPECT_EQ(mKv->Lookup(ToSlice(key1), copyValue), OpCode::kOK);
+    EXPECT_EQ(copiedVal, val1);
+
+    EXPECT_EQ(mKv->Lookup(ToSlice(key2), copyValue), OpCode::kOK);
+    EXPECT_EQ(copiedVal, val2);
+  });
+
+  // commit the transaction in worker 1
+  cr::CRManager::sInstance->scheduleJobSync(
+      1, [&]() { cr::Worker::my().CommitTx(); });
+
+  // still got the old value in worker 2
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    EXPECT_EQ(mKv->Lookup(ToSlice(key1), copyValue), OpCode::kOK);
+    EXPECT_EQ(copiedVal, val1);
+
+    EXPECT_EQ(mKv->Lookup(ToSlice(key2), copyValue), OpCode::kOK);
+    EXPECT_EQ(copiedVal, val2);
+
+    // commit the transaction in worker 2
+    cr::Worker::my().CommitTx();
+  });
+
+  // now worker 2 can not get the old value
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    cr::Worker::my().StartTx(TxMode::kLongRunning,
+                             IsolationLevel::kSnapshotIsolation, false);
+    SCOPED_DEFER(cr::Worker::my().CommitTx());
+
+    EXPECT_EQ(mKv->Lookup(ToSlice(key1), copyValue), OpCode::kNotFound);
+    EXPECT_EQ(mKv->Lookup(ToSlice(key2), copyValue), OpCode::kNotFound);
+  });
+}
+
+TEST_F(LongRunningTxTest, ScanAsc) {
+  // randomly generate 100 unique key-values for s1 to insert
+  size_t numKV = 100;
+  std::unordered_map<std::string, std::string> kvToTest;
+  std::string smallestKey;
+  for (size_t i = 0; i < numKV; ++i) {
+    std::string key = RandomGenerator::RandomAlphString(10);
+    std::string val = RandomGenerator::RandomAlphString(10);
+    if (kvToTest.find(key) != kvToTest.end()) {
+      --i;
+      continue;
+    }
+
+    // update the smallest key
+    kvToTest[key] = val;
+    if (smallestKey.empty() || smallestKey > key) {
+      smallestKey = key;
+    }
+  }
+
+  // insert the key-values in worker 0
+  cr::CRManager::sInstance->scheduleJobSync(0, [&]() {
+    for (const auto& [key, val] : kvToTest) {
+      cr::Worker::my().StartTx();
+      SCOPED_DEFER(cr::Worker::my().CommitTx());
+      EXPECT_EQ(mKv->Insert(ToSlice(key), ToSlice(val)), OpCode::kOK);
+    }
+  });
+
+  // start transaction on worker 2, got the inserted values
+  std::string copiedKey, copiedVal;
+  auto copyKeyVal = [&](Slice key, Slice val) {
+    copiedKey = std::string((const char*)key.data(), key.size());
+    copiedVal = std::string((const char*)val.data(), val.size());
+    EXPECT_EQ(copiedVal, kvToTest[copiedKey]);
+    return true;
+  };
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    cr::Worker::my().StartTx(TxMode::kLongRunning,
+                             IsolationLevel::kSnapshotIsolation, false);
+    EXPECT_EQ(mKv->ScanAsc(ToSlice(smallestKey), copyKeyVal), OpCode::kOK);
+  });
+
+  // remove the key-values in worker 1
+  cr::CRManager::sInstance->scheduleJobSync(1, [&]() {
+    cr::Worker::my().StartTx();
+    for (const auto& [key, val] : kvToTest) {
+      EXPECT_EQ(mKv->Remove(ToSlice(key)), OpCode::kOK);
+    }
+  });
+
+  // got the old values in worker 2
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    EXPECT_EQ(mKv->ScanAsc(ToSlice(smallestKey), copyKeyVal), OpCode::kOK);
+  });
+
+  // commit the transaction in worker 1
+  cr::CRManager::sInstance->scheduleJobSync(
+      1, [&]() { cr::Worker::my().CommitTx(); });
+
+  // still got the old values in worker 2
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    EXPECT_EQ(mKv->ScanAsc(ToSlice(smallestKey), copyKeyVal), OpCode::kOK);
+
+    // commit the transaction in worker 2
+    cr::Worker::my().CommitTx();
+  });
+
+  // now worker 2 can not get the old values
+  cr::CRManager::sInstance->scheduleJobSync(2, [&]() {
+    cr::Worker::my().StartTx(TxMode::kLongRunning,
+                             IsolationLevel::kSnapshotIsolation, false);
+    SCOPED_DEFER(cr::Worker::my().CommitTx());
+    EXPECT_EQ(mKv->ScanAsc(ToSlice(smallestKey), copyKeyVal), OpCode::kOK);
+  });
+}
+
+} // namespace leanstore::test
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/MVCCTest.cpp
+++ b/tests/MVCCTest.cpp
@@ -66,8 +66,8 @@ public:
   }
 
   inline static leanstore::LeanStore* GetLeanStore() {
-    static auto sleanStore = MVCCTest::CreateLeanStore();
-    return sleanStore.get();
+    static auto sLeanStore = MVCCTest::CreateLeanStore();
+    return sLeanStore.get();
   }
 };
 
@@ -100,8 +100,8 @@ TEST_F(MVCCTest, LookupWhileInsert) {
     auto copyValueOut = [&](Slice val) {
       copiedValue = std::string((const char*)val.data(), val.size());
     };
-    cr::Worker::my().StartTx(TxMode::kOLTP, IsolationLevel::kSnapshotIsolation,
-                             true);
+    cr::Worker::my().StartTx(TxMode::kShortRunning,
+                             IsolationLevel::kSnapshotIsolation, true);
     EXPECT_EQ(mBTree->Lookup(Slice((const u8*)key0.data(), key0.size()),
                              copyValueOut),
               OpCode::kOK);
@@ -129,8 +129,8 @@ TEST_F(MVCCTest, LookupWhileInsert) {
     auto copyValueOut = [&](Slice val) {
       copiedValue = std::string((const char*)val.data(), val.size());
     };
-    cr::Worker::my().StartTx(TxMode::kOLTP, IsolationLevel::kSnapshotIsolation,
-                             true);
+    cr::Worker::my().StartTx(TxMode::kShortRunning,
+                             IsolationLevel::kSnapshotIsolation, true);
     EXPECT_EQ(mBTree->Lookup(Slice((const u8*)key1.data(), key1.size()),
                              copyValueOut),
               OpCode::kOK);
@@ -201,8 +201,8 @@ TEST_F(MVCCTest, InsertConflict) {
     auto copyValueOut = [&](Slice val) {
       copiedValue = std::string((const char*)val.data(), val.size());
     };
-    cr::Worker::my().StartTx(TxMode::kOLTP, IsolationLevel::kSnapshotIsolation,
-                             true);
+    cr::Worker::my().StartTx(TxMode::kShortRunning,
+                             IsolationLevel::kSnapshotIsolation, true);
     EXPECT_EQ(mBTree->Lookup(Slice((const u8*)key1.data(), key1.size()),
                              copyValueOut),
               OpCode::kOK);

--- a/tests/TransactionKVTest.cpp
+++ b/tests/TransactionKVTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cmath>
 #include <filesystem>
 #include <memory>
 #include <string>

--- a/tests/TxKV.hpp
+++ b/tests/TxKV.hpp
@@ -50,6 +50,7 @@ class Session {
 public:
   // Transaction operations
   virtual void SetIsolationLevel(IsolationLevel) = 0;
+  virtual void SetTxMode(TxMode) = 0;
   virtual void StartTx() = 0;
   virtual void CommitTx() = 0;
   virtual void AbortTx() = 0;
@@ -116,7 +117,7 @@ class LeanStoreMVCCSession : public Session {
 private:
   WORKERID mWorkerId;
   LeanStoreMVCC* mStore;
-  TxMode mTxMode = TxMode::kOLTP;
+  TxMode mTxMode = TxMode::kShortRunning;
   IsolationLevel mIsolationLevel = IsolationLevel::kSnapshotIsolation;
 
 public:
@@ -130,6 +131,7 @@ public:
 public:
   // Transaction operations
   void SetIsolationLevel(IsolationLevel) override;
+  void SetTxMode(TxMode) override;
   void StartTx() override;
   void CommitTx() override;
   void AbortTx() override;
@@ -199,6 +201,10 @@ inline Session* LeanStoreMVCC::GetSession(WORKERID sessionId) {
 //------------------------------------------------------------------------------
 inline void LeanStoreMVCCSession::SetIsolationLevel(IsolationLevel level) {
   mIsolationLevel = level;
+}
+
+inline void LeanStoreMVCCSession::SetTxMode(TxMode txMode) {
+  mTxMode = txMode;
 }
 
 inline void LeanStoreMVCCSession::StartTx() {


### PR DESCRIPTION
- [ ] Scan from the graveyard
- [ ] Explicitly test OLTP/OLAP watermarks
- [ ] Long-running OLAP transactions should not prevent version GC from OLTP