### PR TITLE
chore: remove WalTxCommit

### DIFF
--- a/src/concurrency/Recovery.cpp
+++ b/src/concurrency/Recovery.cpp
@@ -31,13 +31,6 @@ std::expected<void, utils::Error> Recovery::analysis() {
 
     auto* walEntry = reinterpret_cast<WalEntry*>(walEntryPtr);
     switch (walEntry->mType) {
-    case WalEntry::Type::kTxCommit: {
-      DCHECK_EQ(bytesRead, walEntry->mSize);
-      DCHECK(mActiveTxTable.find(walEntry->mTxId) != mActiveTxTable.end());
-      mActiveTxTable[walEntry->mTxId] = offset;
-      offset += bytesRead;
-      continue;
-    }
     case WalEntry::Type::kTxAbort: {
       DCHECK_EQ(bytesRead, walEntry->mSize);
       DCHECK(mActiveTxTable.find(walEntry->mTxId) != mActiveTxTable.end());

--- a/src/concurrency/WalEntry.hpp
+++ b/src/concurrency/WalEntry.hpp
@@ -18,7 +18,6 @@ namespace leanstore {
 namespace cr {
 
 #define DO_WITH_WAL_ENTRY_TYPES(ACTION, ...)                                   \
-  ACTION(kTxCommit, "kTxCommit", __VA_ARGS__)                                  \
   ACTION(kTxAbort, "kTxAbort", __VA_ARGS__)                                    \
   ACTION(kTxFinish, "kTxFinish", __VA_ARGS__)                                  \
   ACTION(kComplex, "kComplex", __VA_ARGS__)                                    \
@@ -34,7 +33,7 @@ class WalEntrySimple;
 class WalEntryComplex;
 
 /// The basic WAL record representation, there are two kinds of WAL entries:
-/// 1. WalEntrySimple, whose type might be: kTxCommit, kTxAbort
+/// 1. WalEntrySimple, whose type might be: kTxAbort, kTxFinish, kCarriageReturn
 /// 2. WalEntryComplex, whose type is kComplex
 ///
 /// EalEntry size is critical to the write performance, packed attribute is
@@ -172,8 +171,6 @@ inline std::string WalEntry::TypeName() const {
 
 inline void WalEntry::ToJson(const WalEntry* entry, rapidjson::Document* doc) {
   switch (entry->mType) {
-  case Type::kTxCommit:
-    [[fallthrough]];
   case Type::kTxAbort:
     [[fallthrough]];
   case Type::kTxFinish:

--- a/src/concurrency/Worker.cpp
+++ b/src/concurrency/Worker.cpp
@@ -153,7 +153,6 @@ void Worker::CommitTx() {
   }
 
   if (mActiveTx.mIsDurable) {
-    mLogging.WriteSimpleWal(WalEntry::Type::kTxCommit);
     mLogging.WriteSimpleWal(WalEntry::Type::kTxFinish);
   }
 

--- a/tests/concurrency/WalEntryTest.cpp
+++ b/tests/concurrency/WalEntryTest.cpp
@@ -18,7 +18,6 @@ TEST_F(WalEntryTest, Size) {
 
 TEST_F(WalEntryTest, ToJsonString) {
   auto typeNames = std::unordered_map<WalEntry::Type, std::string>{
-      {WalEntry::Type::kTxCommit, "kTxCommit"},
       {WalEntry::Type::kTxAbort, "kTxAbort"},
       {WalEntry::Type::kTxFinish, "kTxFinish"},
       {WalEntry::Type::kCarriageReturn, "kCarriageReturn"},


### PR DESCRIPTION
For normally ended transactions, WalTxFinish is sufficient to indicate the success and finish of the current transaction. Remove WalTxCommit to reduce log size and improve write performance.