### PR TITLE
perf: support ycsb for BasicKV

### DIFF
--- a/benchmarks/micro-benchmarks/InsertUpdateBench.cpp
+++ b/benchmarks/micro-benchmarks/InsertUpdateBench.cpp
@@ -1,10 +1,10 @@
-#include "concurrency/CRManager.hpp"
-#include "leanstore/Config.hpp"
-#include "leanstore/LeanStore.hpp"
 #include "btree/BasicKV.hpp"
 #include "btree/TransactionKV.hpp"
 #include "btree/core/BTreeGeneric.hpp"
 #include "buffer-manager/BufferManager.hpp"
+#include "concurrency/CRManager.hpp"
+#include "leanstore/Config.hpp"
+#include "leanstore/LeanStore.hpp"
 #include "utils/RandomGenerator.hpp"
 
 #include <benchmark/benchmark.h>
@@ -37,10 +37,10 @@ static void BenchUpdateInsert(benchmark::State& state) {
       .mUseBulkInsert = FLAGS_bulk_insert,
   };
   sLeanStore->ExecSync(0, [&]() {
-    cr::Worker::My().StartTx();
-    sLeanStore->CreateTransactionKV(btreeName, btreeConfig, &btree);
-    EXPECT_NE(btree, nullptr);
-    cr::Worker::My().CommitTx();
+    auto res = sLeanStore->CreateTransactionKV(btreeName, btreeConfig);
+    EXPECT_TRUE(res);
+    EXPECT_NE(res.value(), nullptr);
+    btree = res.value();
   });
 
   std::unordered_set<std::string> dedup;

--- a/benchmarks/ycsb/Ycsb.cpp
+++ b/benchmarks/ycsb/Ycsb.cpp
@@ -13,7 +13,8 @@
 // For data preparation
 static std::string kCmdLoad = "load";
 static std::string kCmdRun = "run";
-static std::string kTargetLeanStore = "leanstore";
+static std::string kTargetTransactionKv = "transactionkv";
+static std::string kTargetBasicKv = "basickv";
 static std::string kTargetRocksDb = "rocksdb";
 
 int main(int argc, char** argv) {
@@ -45,8 +46,10 @@ int main(int argc, char** argv) {
   }
 
   leanstore::ycsb::YcsbExecutor* executor = nullptr;
-  if (FLAGS_ycsb_target == kTargetLeanStore) {
-    executor = new leanstore::ycsb::YcsbLeanStore();
+  if (FLAGS_ycsb_target == kTargetTransactionKv ||
+      FLAGS_ycsb_target == kTargetBasicKv) {
+    bool benchTransactionKv = FLAGS_ycsb_target == kTargetTransactionKv;
+    executor = new leanstore::ycsb::YcsbLeanStore(benchTransactionKv);
   } else if (FLAGS_ycsb_target == kTargetRocksDb) {
     // executor = new leanstore::ycsb::YcsbRocksDb();
     LOG(FATAL) << "Unknown target: " << FLAGS_ycsb_target;

--- a/include/leanstore/LeanStore.hpp
+++ b/include/leanstore/LeanStore.hpp
@@ -79,14 +79,12 @@ public:
   ~LeanStore();
 
 public:
-  /// Register a BasicKV
+  /// Create a BasicKV
   ///
   /// @param name The unique name of the btree
   /// @param config The config of the btree
-  /// @param btree The pointer to store the registered btree
-  void CreateBasicKV(const std::string& name,
-                     storage::btree::BTreeConfig& config,
-                     storage::btree::BasicKV** btree);
+  std::expected<storage::btree::BasicKV*, utils::Error> CreateBasicKV(
+      const std::string& name, storage::btree::BTreeConfig& config);
 
   /// Get a registered BasicKV
   ///
@@ -103,9 +101,9 @@ public:
   /// @param name The unique name of the btree
   /// @param config The config of the btree
   /// @param btree The pointer to store the registered btree
-  void CreateTransactionKV(const std::string& name,
-                           storage::btree::BTreeConfig& config,
-                           storage::btree::TransactionKV** btree);
+  std::expected<storage::btree::TransactionKV*, utils::Error>
+  CreateTransactionKV(const std::string& name,
+                      storage::btree::BTreeConfig& config);
 
   /// Get a registered TransactionKV
   ///

--- a/src/btree/TransactionKV.hpp
+++ b/src/btree/TransactionKV.hpp
@@ -117,9 +117,9 @@ private:
   void undoLastRemove(const WalTxRemove* walRemove);
 
 public:
-  static TransactionKV* Create(leanstore::LeanStore* store,
-                               const std::string& treeName, BTreeConfig& config,
-                               BasicKV* graveyard);
+  static std::expected<TransactionKV*, utils::Error> Create(
+      leanstore::LeanStore* store, const std::string& treeName,
+      BTreeConfig& config, BasicKV* graveyard);
 
   inline static void InsertToNode(GuardedBufferFrame<BTreeNode>& guardedNode,
                                   Slice key, Slice val, WORKERID workerId,

--- a/tests/LongRunningTxTest.cpp
+++ b/tests/LongRunningTxTest.cpp
@@ -51,9 +51,9 @@ protected:
         .mUseBulkInsert = FLAGS_bulk_insert,
     };
     mStore->ExecSync(0, [&]() {
-      cr::Worker::My().StartTx();
-      SCOPED_DEFER(cr::Worker::My().CommitTx());
-      mStore->CreateTransactionKV(mTreeName, config, &mKv);
+      auto res = mStore->CreateTransactionKV(mTreeName, config);
+      ASSERT_TRUE(res);
+      mKv = res.value();
       ASSERT_NE(mKv, nullptr);
     });
 

--- a/tests/MvccTest.cpp
+++ b/tests/MvccTest.cpp
@@ -46,10 +46,9 @@ protected:
         .mUseBulkInsert = FLAGS_bulk_insert,
     };
     mStore->ExecSync(0, [&]() {
-      cr::Worker::My().StartTx();
-      SCOPED_DEFER(cr::Worker::My().CommitTx());
-
-      mStore->CreateTransactionKV(mTreeName, config, &mBTree);
+      auto res = mStore->CreateTransactionKV(mTreeName, config);
+      ASSERT_TRUE(res);
+      mBTree = res.value();
       ASSERT_NE(mBTree, nullptr);
     });
   }

--- a/tests/RecoveryTest.cpp
+++ b/tests/RecoveryTest.cpp
@@ -68,9 +68,9 @@ TEST_F(RecoveringTest, SerializeAndDeserialize) {
   };
 
   mStore->ExecSync(0, [&]() {
-    cr::Worker::My().StartTx();
-    SCOPED_DEFER(cr::Worker::My().CommitTx());
-    mStore->CreateTransactionKV(btreeName, btreeConfig, &btree);
+    auto res = mStore->CreateTransactionKV(btreeName, btreeConfig);
+    ASSERT_TRUE(res);
+    btree = res.value();
     EXPECT_NE(btree, nullptr);
   });
 
@@ -145,10 +145,9 @@ TEST_F(RecoveringTest, RecoverAfterInsert) {
   };
 
   mStore->ExecSync(0, [&]() {
-    cr::Worker::My().StartTx();
-    mStore->CreateTransactionKV(btreeName, btreeConfig, &btree);
+    auto res = mStore->CreateTransactionKV(btreeName, btreeConfig);
+    btree = res.value();
     EXPECT_NE(btree, nullptr);
-    cr::Worker::My().CommitTx();
 
     // insert some values
     cr::Worker::My().StartTx();
@@ -246,10 +245,9 @@ TEST_F(RecoveringTest, RecoverAfterUpdate) {
 
   mStore->ExecSync(0, [&]() {
     // create btree
-    cr::Worker::My().StartTx();
-    mStore->CreateTransactionKV(btreeName, btreeConfig, &btree);
+    auto res = mStore->CreateTransactionKV(btreeName, btreeConfig);
+    btree = res.value();
     EXPECT_NE(btree, nullptr);
-    cr::Worker::My().CommitTx();
 
     // insert some values
     for (size_t i = 0; i < numKVs; ++i) {
@@ -341,10 +339,9 @@ TEST_F(RecoveringTest, RecoverAfterRemove) {
         .mEnableWal = FLAGS_wal,
         .mUseBulkInsert = FLAGS_bulk_insert,
     };
-    cr::Worker::My().StartTx();
-    mStore->CreateTransactionKV(btreeName, btreeConfig, &btree);
+    auto res = mStore->CreateTransactionKV(btreeName, btreeConfig);
+    btree = res.value();
     EXPECT_NE(btree, nullptr);
-    cr::Worker::My().CommitTx();
 
     // insert some values
     for (size_t i = 0; i < numKVs; ++i) {


### PR DESCRIPTION
It also refactors the transaction kv and basic kv creation:
- no need to create btrees inside a transaction, btree creation can be regarded as a system transaction
- return error if creation failed