### PR TITLE
fix: Increase AsyncWriteBuffer coverage

### DIFF
--- a/tests/buffer-manager/AsyncWriteBufferTest.cpp
+++ b/tests/buffer-manager/AsyncWriteBufferTest.cpp
@@ -29,7 +29,7 @@ protected:
     BufferFrameHolder(size_t pageSize, PID pageId)
         : mBuffer(512 + pageSize),
           mBf(new(mBuffer.Get()) BufferFrame()) {
-      mBf->mHeader.mPageId = pageId;
+      mBf->Init(pageId);
     }
   };
 
@@ -106,6 +106,11 @@ TEST_F(AsyncWriteBufferTest, Basic) {
   auto doneRequests = result.value();
   EXPECT_EQ(doneRequests, testMaxBatchSize);
   EXPECT_EQ(testWriteBuffer.GetPendingRequests(), 0);
+
+   // check the flushed content
+  testWriteBuffer.IterateFlushedBfs([]([[maybe_unused]]BufferFrame& flushedBf, uint64_t flushedGsn){
+    EXPECT_EQ(flushedGsn, 0);
+  }, testMaxBatchSize);
 
   // read the file content
   for (int i = 0; i < testMaxBatchSize; i++) {


### PR DESCRIPTION
## before

![e0ad2846da4284dcc1df83335c262528](https://github.com/user-attachments/assets/341be1cc-05ad-4202-a319-f41694176336)
the function( IterateFlushedBfs) not cover
![2418f2fb571d429fdf1174366cc2ec4a](https://github.com/user-attachments/assets/38e7ea33-2341-49a6-9375-13eb1c1ec41a)

## after

![51c0ea76038e7bf18f1964ee05d3b0a9](https://github.com/user-attachments/assets/83113581-6688-46b1-8150-3b473f9ccafd)
