### PR TITLE
chore: increase the coverage in page evictor

### DIFF
--- a/src/concurrency/CRManager.cpp
+++ b/src/concurrency/CRManager.cpp
@@ -42,8 +42,10 @@ CRManager::CRManager(leanstore::LeanStore* store) : mStore(store), mGroupCommitt
   // create history storage for each worker
   // History tree should be created after worker thread and group committer are
   // started.
-  mWorkerThreads[0]->SetJob([&]() { setupHistoryStorage4EachWorker(); });
-  mWorkerThreads[0]->Wait();
+  if(storeOption.mWorkerThreads > 0){
+    mWorkerThreads[0]->SetJob([&]() { setupHistoryStorage4EachWorker(); });
+    mWorkerThreads[0]->Wait();
+  }
 }
 
 void CRManager::Stop() {

--- a/tests/buffer-manager/PageEvictorTest.cpp
+++ b/tests/buffer-manager/PageEvictorTest.cpp
@@ -1,0 +1,63 @@
+#include "leanstore/buffer-manager/AsyncWriteBuffer.hpp"
+
+#include "leanstore/buffer-manager/BufferFrame.hpp"
+#include "leanstore/buffer-manager/Swip.hpp"
+#include "leanstore/utils/Defer.hpp"
+#include "leanstore/utils/Log.hpp"
+#include "leanstore/utils/Misc.hpp"
+#include "leanstore/utils/RandomGenerator.hpp"
+#include "leanstore/buffer-manager/PageEvictor.hpp"
+#include "leanstore/buffer-manager/BufferManager.hpp"
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <format>
+
+#include <fcntl.h>
+
+namespace leanstore::storage::test {
+class PageEvictorTest : public ::testing::Test {
+    protected:
+  std::unique_ptr<LeanStore> mStore;
+
+  PageEvictorTest() = default;
+
+  ~PageEvictorTest() = default;
+    void SetUp() override {
+    auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
+    auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
+    const int pageSize = 4096;
+    const int pageHeaderSize = 512;
+    auto res = LeanStore::Open(StoreOption{
+        .mCreateFromScratch = true,
+        .mStoreDir = "/tmp/" + curTestName,
+        .mLogLevel = LogLevel::kDebug,
+        .mWorkerThreads = 2,
+        .mNumPartitions = 1,
+        .mBufferPoolSize = 70 * (pageHeaderSize + pageSize),
+        .mFreePct = 20,
+        .mEnableBulkInsert = false,
+        .mEnableEagerGc = false,
+        
+    });
+    ASSERT_TRUE(res);
+    mStore = std::move(res.value());
+    
+  }
+};
+
+TEST_F(PageEvictorTest, pageEvictBasic) {
+  EXPECT_EQ(mStore->mBufferManager->mPageEvictors.size(), 1);
+  auto& pageEvictor = mStore->mBufferManager->mPageEvictors[0];
+  EXPECT_TRUE(pageEvictor->IsStarted());
+  EXPECT_EQ(pageEvictor->mPartitions.size(), 1);
+  EXPECT_FALSE(pageEvictor->mPartitions[0]->NeedMoreFreeBfs());
+  pageEvictor->PickBufferFramesToCool(*pageEvictor->mPartitions[0]);
+  pageEvictor->PrepareAsyncWriteBuffer(*pageEvictor->mPartitions[0]);
+  pageEvictor->FlushAndRecycleBufferFrames(*pageEvictor->mPartitions[0]);
+}
+
+} // namespace leanstore::storage::test


### PR DESCRIPTION
from 3.85 to 17.3%
## before
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/40e0818c-bc6d-4ff4-8fe9-2e9e7591fae5">

## after

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/cee67a14-c168-4792-86e0-991d9b359123">

## some problems

this function has some thread problems(potential deadlock). it can't pass tsan check, and I will fix it in next PR
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/84c0375f-4323-4a9a-93f4-993e38b77d73">


