### PR TITLE
fix: fix iteration on empty tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       run: cppcheck --project=build/debug_tsan/compile_commands.json -i tests --error-exitcode=1
 
     - name: Check clang-format
-      run: cmake --build build/debug_tsan --target=check-format || echo "please fix code format via 'cmake --build build/debug_tsan --target=format'"
+      run: cmake --build build/debug_tsan --target=check-format 
 
     - name: Build project
       run: cmake --build build/debug_tsan -j `nproc`

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,7 +36,7 @@
             "inherits": "base_debug",
             "binaryDir": "${sourceDir}/build/debug",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "dist/debug",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/debug",
                 "ENABLE_COVERAGE": "ON"
             }
         },
@@ -45,7 +45,7 @@
             "inherits": "base_debug",
             "binaryDir": "${sourceDir}/build/debug_tsan",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "dist/debug_tsan",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/debug_tsan",
                 "ENABLE_TSAN": "ON",
                 "ENABLE_COVERAGE": "ON"
             }
@@ -55,7 +55,7 @@
             "inherits": "base_release",
             "binaryDir": "${sourceDir}/build/release",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "dist/release"
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/release"
             }
         },
         {
@@ -63,7 +63,7 @@
             "inherits": "base_release",
             "binaryDir": "${sourceDir}/build/performance",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "dist/performance",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/performance",
                 "ENABLE_ROCKSDB": "ON"
             }
         }

--- a/include/leanstore/btree/core/PessimisticIterator.hpp
+++ b/include/leanstore/btree/core/PessimisticIterator.hpp
@@ -110,6 +110,7 @@ public:
     seekToTargetPage([](GuardedBufferFrame<BTreeNode>&) { return 0; });
     if (mGuardedLeaf->mNumSeps == 0) {
       SetToInvalid();
+      return;
     }
     mSlotId = 0;
   }
@@ -130,7 +131,7 @@ public:
   //! @return true if the next key exists, false otherwise
   bool HasNext() override {
     // iterator is not initialized, return false
-    if (mSlotId == -1) {
+    if (!Valid()) {
       return false;
     }
 
@@ -183,7 +184,7 @@ public:
   //! @return true if the previous key exists, false otherwise
   bool HasPrev() override {
     // iterator is not initialized, return false
-    if (mSlotId == -1) {
+    if (!Valid()) {
       return false;
     }
 


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

- fix iteration on empty btree
- format check should fail if violated