### PR TITLE
chore: expose StoreOption to c API

### DIFF
--- a/benchmarks/micro-benchmarks/InsertUpdateBench.cpp
+++ b/benchmarks/micro-benchmarks/InsertUpdateBench.cpp
@@ -1,5 +1,5 @@
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/btree/BasicKV.hpp"
 #include "leanstore/btree/TransactionKV.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
@@ -21,11 +21,11 @@ static void BenchUpdateInsert(benchmark::State& state) {
   std::filesystem::path dirPath = "/tmp/InsertUpdateBench";
   std::filesystem::remove_all(dirPath);
   std::filesystem::create_directories(dirPath);
-  auto sLeanStore = std::make_unique<leanstore::LeanStore>(StoreOption{
-      .mCreateFromScratch = true,
-      .mStoreDir = "/tmp/InsertUpdateBench",
-      .mWorkerThreads = 4,
-  });
+
+  StoreOption* option = CreateStoreOption("/tmp/InsertUpdateBench");
+  option->mCreateFromScratch = true;
+  option->mWorkerThreads = 4;
+  auto sLeanStore = std::make_unique<leanstore::LeanStore>(option);
 
   storage::btree::TransactionKV* btree;
 

--- a/examples/c/BasicKvExample.c
+++ b/examples/c/BasicKvExample.c
@@ -1,13 +1,24 @@
+#include "leanstore-c/StoreOption.h"
+#include "leanstore-c/leanstore-c.h"
+
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "leanstore/leanstore-c.h"
-
 int main() {
-  LeanStoreHandle* storeHandle =
-      CreateLeanStore(1, "/tmp/leanstore/examples/BasicKvExample", 2, 0, 1);
+  struct StoreOption* option = CreateStoreOption("/tmp/leanstore/examples/BasicKvExample");
+  option->mCreateFromScratch = 1;
+  option->mWorkerThreads = 2;
+  option->mEnableBulkInsert = 0;
+  option->mEnableEagerGc = 1;
+  LeanStoreHandle* storeHandle = CreateLeanStore(option);
   BasicKvHandle* kvHandle = CreateBasicKV(storeHandle, 0, "testTree1");
+  if (kvHandle == NULL) {
+    DestroyStoreOption(option);
+    printf("create basic kv failed\n");
+    return -1;
+  }
 
   // key-value pair 1
   StringSlice keySlice;

--- a/examples/cpp/BasicKvExample.cpp
+++ b/examples/cpp/BasicKvExample.cpp
@@ -1,3 +1,4 @@
+#include <leanstore-c/StoreOption.h>
 #include <leanstore/LeanStore.hpp>
 #include <leanstore/btree/BasicKV.hpp>
 #include <leanstore/concurrency/Worker.hpp>
@@ -6,18 +7,19 @@
 #include <memory>
 
 using leanstore::LeanStore;
-using leanstore::StoreOption;
 
 int main() {
+  // create store option
+  StoreOption* option = CreateStoreOption("/tmp/leanstore/examples/BasicKvExample");
+  option->mCreateFromScratch = true;
+  option->mWorkerThreads = 2;
+  option->mEnableBulkInsert = false;
+  option->mEnableEagerGc = true;
+
   // create store
-  auto res = LeanStore::Open(StoreOption{
-      .mCreateFromScratch = true,
-      .mStoreDir = "/tmp/leanstore/examples/BasicKvExample",
-      .mWorkerThreads = 2,
-      .mEnableBulkInsert = false,
-      .mEnableEagerGc = true,
-  });
+  auto res = LeanStore::Open(option);
   if (!res) {
+    DestroyStoreOption(option);
     std::cerr << "open store failed: " << res.error().ToString() << std::endl;
     return 1;
   }

--- a/include/leanstore-c/StoreOption.h
+++ b/include/leanstore-c/StoreOption.h
@@ -1,186 +1,201 @@
-#pragma once
+#ifndef LEANSTORE_STORE_OPTION_H
+#define LEANSTORE_STORE_OPTION_H
 
-#include <cstdint>
-#include <string>
+#include <stdbool.h>
+#include <stdint.h>
 
-namespace leanstore {
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-enum class LogLevel : uint8_t {
+//! The log level
+typedef enum LogLevel {
   kDebug = 0,
   kInfo,
   kWarn,
   kError,
-};
+} LogLevel;
 
-class StoreOption {
-public:
+//! The options for creating a new store.
+typedef struct StoreOption {
   // ---------------------------------------------------------------------------
   // Store related options
   // ---------------------------------------------------------------------------
 
   //! Whether to create store from scratch.
-  bool mCreateFromScratch = true;
+  bool mCreateFromScratch;
 
   //! The directory for all the database files.
-  std::string mStoreDir = "~/.leanstore";
+  const char* mStoreDir;
 
   // ---------------------------------------------------------------------------
   // log related options
   // ---------------------------------------------------------------------------
 
   //! The log level
-  LogLevel mLogLevel = LogLevel::kInfo;
+  LogLevel mLogLevel;
 
   // ---------------------------------------------------------------------------
   // Worker thread related options
   // ---------------------------------------------------------------------------
 
   //! The number of worker threads.
-  uint64_t mWorkerThreads = 4;
+  uint64_t mWorkerThreads;
 
   //! The WAL buffer size for each worker (bytes).
-  uint64_t mWalBufferSize = 10 * 1024 * 1024;
+  uint64_t mWalBufferSize;
 
   // ---------------------------------------------------------------------------
   // Buffer pool related options
   // ---------------------------------------------------------------------------
 
   //! The page size (bytes). For buffer manager.
-  uint64_t mPageSize = 4 * 1024;
+  uint64_t mPageSize;
 
-  uint64_t mBufferFrameSize = 512 + mPageSize;
+  uint64_t mBufferFrameSize;
 
   //! The number of partitions. For buffer manager.
-  uint32_t mNumPartitions = 64;
+  uint32_t mNumPartitions;
 
   //! The buffer pool size (bytes). For buffer manager.
-  uint64_t mBufferPoolSize = 1ull * 1024 * 1024 * 1024;
+  uint64_t mBufferPoolSize;
 
   //! The free percentage of the buffer pool. In the range of [0, 100].
-  uint32_t mFreePct = 1;
+  uint32_t mFreePct;
 
   //! The number of page evictor threads.
-  uint32_t mNumBufferProviders = 1;
+  uint32_t mNumBufferProviders;
 
   //! The async buffer
-  uint32_t mBufferWriteBatchSize = 1024;
+  uint32_t mBufferWriteBatchSize;
 
   //! Whether to perform crc check for buffer frames.
-  bool mEnableBufferCrcCheck = false;
+  bool mEnableBufferCrcCheck;
 
   //! BufferFrame recycle batch size. Everytime a batch of buffer frames is
   //! randomly picked and verified by page evictors, some of them are COOLed,
   //! some of them are EVICted.
-  uint64_t mBufferFrameRecycleBatchSize = 64;
+  uint64_t mBufferFrameRecycleBatchSize;
 
   //! Whether to reclaim unused free page ids
-  bool mEnableReclaimPageIds = true;
+  bool mEnableReclaimPageIds;
 
   // ---------------------------------------------------------------------------
   // Logging and recovery related options
   // ---------------------------------------------------------------------------
 
   //! Whether to enable write-ahead log.
-  bool mEnableWal = true;
+  bool mEnableWal;
 
   //! Whether to execute fsync after each WAL write.
-  bool mEnableWalFsync = false;
+  bool mEnableWalFsync;
 
   // ---------------------------------------------------------------------------
   // Generic BTree related options
   // ---------------------------------------------------------------------------
 
-  bool mEnableBulkInsert = false;
+  //! Whether to enable bulk insert.
+  bool mEnableBulkInsert;
 
   //! Whether to enable X-Merge
-  bool mEnableXMerge = false;
+  bool mEnableXMerge;
 
-  uint64_t mXMergeK = 5;
+  //! The number of children to merge in X-Merge
+  uint64_t mXMergeK;
 
-  double mXMergeTargetPct = 80;
+  //! The target percentage of the number of children to merge in X-Merge
+  double mXMergeTargetPct;
 
   //! Whether to enable contention split.
-  bool mEnableContentionSplit = true;
+  bool mEnableContentionSplit;
 
   //! Contention split probability, as exponent of 2
-  uint64_t mContentionSplitProbility = 14;
+  uint64_t mContentionSplitProbility;
 
   //! Contention stats sample probability, as exponent of 2
-  uint64_t mContentionSplitSampleProbability = 7;
+  uint64_t mContentionSplitSampleProbability;
 
   //! Contention percentage to trigger the split, in the range of [0, 100].
-  uint64_t mContentionSplitThresholdPct = 1;
+  uint64_t mContentionSplitThresholdPct;
 
   //! Whether to enable btree hints optimization. Available options:
   //! 0: disabled
   //! 1: serial
   //! 2: AVX512
-  int64_t mBTreeHints = 1;
+  int64_t mBTreeHints;
 
   //! Whether to enable heads optimization in LowerBound search.
-  bool mEnableHeadOptimization = true;
+  bool mEnableHeadOptimization;
 
   //! Whether to enable optimistic scan. Jump to next leaf directly if the
   //! pointer in the parent has not changed
-  bool mEnableOptimisticScan = true;
+  bool mEnableOptimisticScan;
 
   // ---------------------------------------------------------------------------
   // Transaction related options
   // ---------------------------------------------------------------------------
 
   //! Whether to enable long running transaction.
-  bool mEnableLongRunningTx = true;
+  bool mEnableLongRunningTx;
 
   //! Whether to enable fat tuple.
-  bool mEnableFatTuple = false;
+  bool mEnableFatTuple;
 
   //! Whether to enable garbage collection.
-  bool mEnableGc = true;
+  bool mEnableGc;
 
   //! Whether to enable eager garbage collection. To enable eager garbage
   //! collection, the garbage collection must be enabled first. Once enabled,
   //! the garbage collection will be triggered after each transaction commit and
   //! abort.
-  bool mEnableEagerGc = false;
+  bool mEnableEagerGc;
 
   // ---------------------------------------------------------------------------
   // Metrics related options
   // ---------------------------------------------------------------------------
 
   //! Whether to enable metrics.
-  bool mEnableMetrics = false;
+  bool mEnableMetrics;
 
   //! The metrics port.
-  int32_t mMetricsPort = 8080;
+  int32_t mMetricsPort;
 
-  bool mEnableCpuCounters = true;
+  //! Whether to enable cpu counters.
+  bool mEnableCpuCounters;
 
-  bool mEnableTimeMeasure = false;
+  //! Whether to enable time measure.
+  bool mEnableTimeMeasure;
 
-  bool mEnablePerfEvents = false;
+  //! Whether to enable perf events.
+  bool mEnablePerfEvents;
 
-  //! Helper functions
-  std::string GetMetaFilePath() const {
-    return mStoreDir + "/db.meta.json";
-  }
+} StoreOption;
 
-  std::string GetDbFilePath() const {
-    return mStoreDir + "/db.pages";
-  }
+//! Create a new store option.
+//! @param storeDir the directory for all the database files. The string content is deep copied to
+//!                 the created store option.
+StoreOption* CreateStoreOption(const char* storeDir);
 
-  std::string GetWalFilePath() const {
-    return mStoreDir + "/db.wal";
-  }
+//! Create a new store option from an existing store option.
+//! @param storeDir the existing store option.
+StoreOption* CreateStoreOptionFrom(const StoreOption* storeDir);
 
-  std::string GetLogPath() const {
-    return mStoreDir + "/db.log";
-  }
-};
+//! Destroy a store option.
+//! @param option the store option to destroy.
+void DestroyStoreOption(const StoreOption* option);
 
-class BTreeConfig {
-public:
-  bool mEnableWal = true;
-  bool mUseBulkInsert = false;
-};
+//! The options for creating a new BTree.
+typedef struct BTreeConfig {
+  //! Whether to enable write-ahead log.
+  bool mEnableWal;
 
-} // namespace leanstore
+  //! Whether to enable bulk insert.
+  bool mUseBulkInsert;
+
+} BTreeConfig;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LEANSTORE_STORE_OPTION_H

--- a/include/leanstore-c/leanstore-c.h
+++ b/include/leanstore-c/leanstore-c.h
@@ -1,6 +1,9 @@
 #ifndef LEANSTORE_C_H
 #define LEANSTORE_C_H
 
+#include "leanstore-c/StoreOption.h"
+
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -49,9 +52,7 @@ typedef struct StringSlice {
 typedef struct LeanStoreHandle LeanStoreHandle;
 
 //! Create and init a leanstore instance
-LeanStoreHandle* CreateLeanStore(int8_t createFromScratch, const char* storeDir,
-                                 uint64_t workerThreads, int8_t enableBulkInsert,
-                                 int8_t enableEagerGc);
+LeanStoreHandle* CreateLeanStore(StoreOption* option);
 
 //! Deinit and destroy a leanstore instance
 void DestroyLeanStore(LeanStoreHandle* handle);
@@ -72,7 +73,7 @@ void DestroyBasicKV(BasicKvHandle* handle);
 
 //! Insert a key-value pair into a basic key-value store at workerId
 //! @return true if the insert is successful, false otherwise
-uint8_t BasicKvInsert(BasicKvHandle* handle, uint64_t workerId, StringSlice key, StringSlice val);
+bool BasicKvInsert(BasicKvHandle* handle, uint64_t workerId, StringSlice key, StringSlice val);
 
 //! Lookup a key in a basic key-value store at workerId
 //! NOTE: The caller should destroy the val after use via DestroyString()
@@ -81,7 +82,7 @@ String* BasicKvLookup(BasicKvHandle* handle, uint64_t workerId, StringSlice key)
 
 //! Remove a key in a basic key-value store at workerId
 //! @return true if the key is found and removed, false otherwise
-uint8_t BasicKvRemove(BasicKvHandle* handle, uint64_t workerId, StringSlice key);
+bool BasicKvRemove(BasicKvHandle* handle, uint64_t workerId, StringSlice key);
 
 //! Get the size of a basic key-value store at workerId
 //! @return the number of entries in the basic key-value store
@@ -116,7 +117,7 @@ void BasicKvIterSeekToFirstGreaterEqual(BasicKvIterHandle* handle, uint64_t work
 
 //! Whether the iterator has a next key in a basic key-value store at workerId
 //! @return true if the next key exists, false otherwise
-uint8_t BasicKvIterHasNext(BasicKvIterHandle* handle, uint64_t workerId);
+bool BasicKvIterHasNext(BasicKvIterHandle* handle, uint64_t workerId);
 
 //! Iterate to the next key in a basic key-value store at workerId
 void BasicKvIterNext(BasicKvIterHandle* handle, uint64_t workerId);
@@ -133,7 +134,7 @@ void BasicKvIterSeekToLastLessEqual(BasicKvIterHandle* handle, uint64_t workerId
 
 //! Whether the iterator has a previous key in a basic key-value store at workerId
 //! @return true if the previous key exists, false otherwise
-uint8_t BasicKvIterHasPrev(BasicKvIterHandle* handle, uint64_t workerId);
+bool BasicKvIterHasPrev(BasicKvIterHandle* handle, uint64_t workerId);
 
 //! Iterate to the previous key in a basic key-value store at workerId
 void BasicKvIterPrev(BasicKvIterHandle* handle, uint64_t workerId);
@@ -143,7 +144,7 @@ void BasicKvIterPrev(BasicKvIterHandle* handle, uint64_t workerId);
 //------------------------------------------------------------------------------
 
 //! Whether the iterator is valid
-uint8_t BasicKvIterValid(BasicKvIterHandle* handle);
+bool BasicKvIterValid(BasicKvIterHandle* handle);
 
 //! Get the key of the current iterator position in a basic key-value store at workerId
 //! @return the read-only key slice

--- a/include/leanstore/btree/ChainedTuple.hpp
+++ b/include/leanstore/btree/ChainedTuple.hpp
@@ -76,7 +76,7 @@ public:
     bool commandValid = mCommandId != kInvalidCommandid;
     bool hasLongRunningOLAP =
         cr::Worker::My().mStore->mCRManager->mGlobalWmkInfo.HasActiveLongRunningTx();
-    bool frequentlyUpdated = mTotalUpdates > cr::Worker::My().mStore->mStoreOption.mWorkerThreads;
+    bool frequentlyUpdated = mTotalUpdates > cr::Worker::My().mStore->mStoreOption->mWorkerThreads;
     bool recentUpdatedByOthers =
         mWorkerId != cr::Worker::My().mWorkerId || mTxId != cr::ActiveTx().mStartTs;
     return commandValid && hasLongRunningOLAP && recentUpdatedByOthers && frequentlyUpdated;

--- a/include/leanstore/btree/TransactionKV.hpp
+++ b/include/leanstore/btree/TransactionKV.hpp
@@ -109,7 +109,7 @@ public:
   }
 
   inline static uint64_t ConvertToFatTupleThreshold() {
-    return cr::Worker::My().mStore->mStoreOption.mWorkerThreads;
+    return cr::Worker::My().mStore->mStoreOption->mWorkerThreads;
   }
 
   //! Updates the value stored in FatTuple. The former newest version value is

--- a/include/leanstore/btree/core/BTreeGeneric.hpp
+++ b/include/leanstore/btree/core/BTreeGeneric.hpp
@@ -241,7 +241,7 @@ inline void BTreeGeneric::IterateChildSwips(BufferFrame& bf, std::function<bool(
 }
 
 inline SpaceCheckResult BTreeGeneric::CheckSpaceUtilization(BufferFrame& bf) {
-  if (!mStore->mStoreOption.mEnableXMerge) {
+  if (!mStore->mStoreOption->mEnableXMerge) {
     return SpaceCheckResult::kNothing;
   }
 
@@ -262,7 +262,7 @@ inline SpaceCheckResult BTreeGeneric::CheckSpaceUtilization(BufferFrame& bf) {
 }
 
 inline void BTreeGeneric::Checkpoint(BufferFrame& bf, void* dest) {
-  std::memcpy(dest, &bf.mPage, mStore->mStoreOption.mPageSize);
+  std::memcpy(dest, &bf.mPage, mStore->mStoreOption->mPageSize);
   auto* destPage = reinterpret_cast<Page*>(dest);
   auto* destNode = reinterpret_cast<BTreeNode*>(destPage->mPayload);
 

--- a/include/leanstore/btree/core/BTreeNode.hpp
+++ b/include/leanstore/btree/core/BTreeNode.hpp
@@ -456,7 +456,7 @@ public:
   }
 
   static uint16_t Size() {
-    return static_cast<uint16_t>(utils::tlsStore->mStoreOption.mPageSize - sizeof(Page));
+    return static_cast<uint16_t>(utils::tlsStore->mStoreOption->mPageSize - sizeof(Page));
   }
 
   static uint16_t UnderFullSize() {
@@ -528,7 +528,7 @@ int16_t BTreeNode::LowerBound(Slice key, bool* isEqual) {
   SearchHint(keyHead, lower, upper);
   while (lower < upper) {
     bool foundEqual(false);
-    if (utils::tlsStore->mStoreOption.mEnableHeadOptimization) {
+    if (utils::tlsStore->mStoreOption->mEnableHeadOptimization) {
       foundEqual = shrinkSearchRangeWithHead(lower, upper, key, keyHead);
     } else {
       foundEqual = shrinkSearchRange(lower, upper, key);

--- a/include/leanstore/btree/core/PessimisticExclusiveIterator.hpp
+++ b/include/leanstore/btree/core/PessimisticExclusiveIterator.hpp
@@ -130,14 +130,14 @@ public:
 
   //! Updates contention statistics after each slot modification on the page.
   virtual void UpdateContentionStats() {
-    if (!utils::tlsStore->mStoreOption.mEnableContentionSplit) {
+    if (!utils::tlsStore->mStoreOption->mEnableContentionSplit) {
       return;
     }
     const uint64_t randomNumber = utils::RandomGenerator::RandU64();
 
     // haven't met the contention stats update probability
     if ((randomNumber &
-         ((1ull << utils::tlsStore->mStoreOption.mContentionSplitSampleProbability) - 1)) != 0) {
+         ((1ull << utils::tlsStore->mStoreOption->mContentionSplitSampleProbability) - 1)) != 0) {
       return;
     }
     auto& contentionStats = mGuardedLeaf.mBf->mHeader.mContentionStats;
@@ -148,14 +148,14 @@ public:
             mGuardedLeaf.mBf->mHeader.mPageId, mSlotId, mGuardedLeaf.EncounteredContention());
 
     // haven't met the contention split validation probability
-    if ((randomNumber & ((1ull << utils::tlsStore->mStoreOption.mContentionSplitProbility) - 1)) !=
+    if ((randomNumber & ((1ull << utils::tlsStore->mStoreOption->mContentionSplitProbility) - 1)) !=
         0) {
       return;
     }
     auto contentionPct = contentionStats.ContentionPercentage();
     contentionStats.Reset();
     if (lastUpdatedSlot != mSlotId &&
-        contentionPct >= utils::tlsStore->mStoreOption.mContentionSplitThresholdPct &&
+        contentionPct >= utils::tlsStore->mStoreOption->mContentionSplitThresholdPct &&
         mGuardedLeaf->mNumSeps > 2) {
       int16_t splitSlot = std::min<int16_t>(lastUpdatedSlot, mSlotId);
       mGuardedLeaf.unlock();

--- a/include/leanstore/btree/core/PessimisticIterator.hpp
+++ b/include/leanstore/btree/core/PessimisticIterator.hpp
@@ -356,7 +356,7 @@ inline void PessimisticIterator::Next() {
       mFuncCleanUp = nullptr;
     }
 
-    if (utils::tlsStore->mStoreOption.mEnableOptimisticScan && mLeafPosInParent != -1) {
+    if (utils::tlsStore->mStoreOption->mEnableOptimisticScan && mLeafPosInParent != -1) {
       JUMPMU_TRY() {
         if ((mLeafPosInParent + 1) <= mGuardedParent->mNumSeps) {
           int32_t nextLeafPos = mLeafPosInParent + 1;
@@ -463,7 +463,7 @@ inline void PessimisticIterator::Prev() {
       mFuncCleanUp = nullptr;
     }
 
-    if (utils::tlsStore->mStoreOption.mEnableOptimisticScan && mLeafPosInParent != -1) {
+    if (utils::tlsStore->mStoreOption->mEnableOptimisticScan && mLeafPosInParent != -1) {
       JUMPMU_TRY() {
         if ((mLeafPosInParent - 1) >= 0) {
           int32_t nextLeafPos = mLeafPosInParent - 1;

--- a/include/leanstore/buffer-manager/BufferFrame.hpp
+++ b/include/leanstore/buffer-manager/BufferFrame.hpp
@@ -144,7 +144,7 @@ public:
 
 public:
   uint64_t CRC() {
-    return utils::CRC(mPayload, utils::tlsStore->mStoreOption.mPageSize - sizeof(Page));
+    return utils::CRC(mPayload, utils::tlsStore->mStoreOption->mPageSize - sizeof(Page));
   }
 };
 

--- a/include/leanstore/buffer-manager/BufferManager.hpp
+++ b/include/leanstore/buffer-manager/BufferManager.hpp
@@ -93,7 +93,7 @@ public:
   //! Randomly pick a buffer frame.
   BufferFrame& RandomBufferFrame() {
     auto bfId = utils::RandomGenerator::Rand<uint64_t>(0, mNumBfs);
-    auto* bfAddr = &mBufferPool[bfId * mStore->mStoreOption.mBufferFrameSize];
+    auto* bfAddr = &mBufferPool[bfId * mStore->mStoreOption->mBufferFrameSize];
     return *reinterpret_cast<BufferFrame*>(bfAddr);
   }
 
@@ -155,7 +155,7 @@ public:
 private:
   Result<void> writePage(PID pageId, void* buffer) {
     utils::AsyncIo aio(1);
-    const auto pageSize = mStore->mStoreOption.mPageSize;
+    const auto pageSize = mStore->mStoreOption->mPageSize;
     DEBUG_BLOCK() {
       auto* page [[maybe_unused]] = reinterpret_cast<Page*>(buffer);
       LS_DLOG("page write, pageId={}, btreeId={}", pageId, page->mBTreeId);

--- a/include/leanstore/buffer-manager/PageEvictor.hpp
+++ b/include/leanstore/buffer-manager/PageEvictor.hpp
@@ -84,11 +84,11 @@ public:
         mFD(store->mPageFd),
         mCoolCandidateBfs(),
         mEvictCandidateBfs(),
-        mAsyncWriteBuffer(store->mPageFd, store->mStoreOption.mPageSize,
-                          mStore->mStoreOption.mBufferWriteBatchSize),
+        mAsyncWriteBuffer(store->mPageFd, store->mStoreOption->mPageSize,
+                          mStore->mStoreOption->mBufferWriteBatchSize),
         mFreeBfList() {
-    mCoolCandidateBfs.reserve(mStore->mStoreOption.mBufferFrameRecycleBatchSize);
-    mEvictCandidateBfs.reserve(mStore->mStoreOption.mBufferFrameRecycleBatchSize);
+    mCoolCandidateBfs.reserve(mStore->mStoreOption->mBufferFrameRecycleBatchSize);
+    mEvictCandidateBfs.reserve(mStore->mStoreOption->mBufferFrameRecycleBatchSize);
   }
 
   // no copy and assign

--- a/include/leanstore/concurrency/Transaction.hpp
+++ b/include/leanstore/concurrency/Transaction.hpp
@@ -83,7 +83,7 @@ public:
     mTxMode = mode;
     mTxIsolationLevel = level;
     mHasWrote = false;
-    mIsDurable = utils::tlsStore->mStoreOption.mEnableWal;
+    mIsDurable = utils::tlsStore->mStoreOption->mEnableWal;
     mWalExceedBuffer = false;
   }
 

--- a/include/leanstore/concurrency/WorkerThread.hpp
+++ b/include/leanstore/concurrency/WorkerThread.hpp
@@ -58,7 +58,7 @@ protected:
 };
 
 inline void WorkerThread::runImpl() {
-  if (utils::tlsStore->mStoreOption.mEnableCpuCounters) {
+  if (utils::tlsStore->mStoreOption->mEnableCpuCounters) {
     CPUCounters::registerThread(mThreadName, false);
   }
 

--- a/include/leanstore/utils/Log.hpp
+++ b/include/leanstore/utils/Log.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "leanstore/StoreOption.hpp"
+#include "leanstore-c/StoreOption.h"
 
 #include <format>
 #include <mutex>
@@ -20,7 +20,7 @@ public:
   inline static bool sInited = false;
   inline static std::mutex sInitMutex;
 
-  static void Init(const StoreOption& option);
+  static void Init(const StoreOption* option);
 
   static void DebugCheck(bool condition, const std::string& msg = "");
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ install(TARGETS leanstore
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY
   ${CMAKE_SOURCE_DIR}/include/leanstore
+  ${CMAKE_SOURCE_DIR}/include/leanstore-c
   DESTINATION include)
 
 # ------------------------------------------------------------------------------

--- a/src/btree/TransactionKV.cpp
+++ b/src/btree/TransactionKV.cpp
@@ -177,7 +177,7 @@ OpCode TransactionKV::UpdatePartial(Slice key, MutValCallback updateCallBack,
 
         // convert to fat tuple if it's frequently updated by me and other
         // workers
-        if (mStore->mStoreOption.mEnableFatTuple && chainedTuple.ShouldConvertToFatTuple()) {
+        if (mStore->mStoreOption->mEnableFatTuple && chainedTuple.ShouldConvertToFatTuple()) {
           chainedTuple.mTotalUpdates = 0;
           auto succeed = Tuple::ToFat(xIter);
           if (succeed) {
@@ -659,7 +659,7 @@ bool TransactionKV::UpdateInFatTuple(PessimisticExclusiveIterator& xIter, Slice 
 }
 
 SpaceCheckResult TransactionKV::CheckSpaceUtilization(BufferFrame& bf) {
-  if (!mStore->mStoreOption.mEnableXMerge) {
+  if (!mStore->mStoreOption->mEnableXMerge) {
     return SpaceCheckResult::kNothing;
   }
 

--- a/src/btree/core/BTreeGeneric.cpp
+++ b/src/btree/core/BTreeGeneric.cpp
@@ -438,7 +438,7 @@ BTreeGeneric::XMergeReturnCode BTreeGeneric::XMerge(GuardedBufferFrame<BTreeNode
     return XMergeReturnCode::kNothing;
   }
 
-  int64_t maxMergePages = mStore->mStoreOption.mXMergeK;
+  int64_t maxMergePages = mStore->mStoreOption->mXMergeK;
   GuardedBufferFrame<BTreeNode> guardedNodes[maxMergePages];
   bool fullyMerged[maxMergePages];
 

--- a/src/btree/core/BTreeNode.cpp
+++ b/src/btree/core/BTreeNode.cpp
@@ -22,7 +22,7 @@ void BTreeNode::UpdateHint(uint16_t slotId) {
 
 void BTreeNode::SearchHint(HeadType keyHead, uint16_t& lowerOut, uint16_t& upperOut) {
   if (mNumSeps > sHintCount * 2) {
-    if (utils::tlsStore->mStoreOption.mBTreeHints == 2) {
+    if (utils::tlsStore->mStoreOption->mBTreeHints == 2) {
 #ifdef __AVX512F__
       const uint16_t dist = mNumSeps / (sHintCount + 1);
       uint16_t pos, pos2;
@@ -45,7 +45,7 @@ void BTreeNode::SearchHint(HeadType keyHead, uint16_t& lowerOut, uint16_t& upper
 #else
       Log::Error("Search hint with AVX512 failed: __AVX512F__ not found");
 #endif
-    } else if (utils::tlsStore->mStoreOption.mBTreeHints == 1) {
+    } else if (utils::tlsStore->mStoreOption->mBTreeHints == 1) {
       const uint16_t dist = mNumSeps / (sHintCount + 1);
       uint16_t pos, pos2;
 

--- a/src/buffer-manager/PageEvictor.cpp
+++ b/src/buffer-manager/PageEvictor.cpp
@@ -211,7 +211,7 @@ void PageEvictor::PickBufferFramesToCool(Partition& targetPartition) {
 
 void PageEvictor::randomBufferFramesToCoolOrEvict() {
   mCoolCandidateBfs.clear();
-  for (auto i = 0u; i < mStore->mStoreOption.mBufferFrameRecycleBatchSize; i++) {
+  for (auto i = 0u; i < mStore->mStoreOption->mBufferFrameRecycleBatchSize; i++) {
     auto* randomBf = &mStore->mBufferManager->RandomBufferFrame();
     DO_NOT_OPTIMIZE(randomBf->mHeader.mState);
     mCoolCandidateBfs.push_back(randomBf);
@@ -274,7 +274,7 @@ void PageEvictor::PrepareAsyncWriteBuffer(Partition& targetPartition) {
       cooledBf->mHeader.mIsBeingWrittenBack.store(true, std::memory_order_release);
 
       // performs crc check if necessary
-      if (mStore->mStoreOption.mEnableBufferCrcCheck) {
+      if (mStore->mStoreOption->mEnableBufferCrcCheck) {
         cooledBf->mHeader.mCrc = cooledBf->mPage.CRC();
       }
 
@@ -362,7 +362,7 @@ void PageEvictor::evictFlushedBf(BufferFrame& cooledBf, BMOptimisticGuard& optim
   BMExclusiveUpgradeIfNeeded parentWriteGuard(parentHandler.mParentGuard);
   optimisticGuard.mGuard.ToExclusiveMayJump();
 
-  if (mStore->mStoreOption.mEnableBufferCrcCheck && cooledBf.mHeader.mCrc) {
+  if (mStore->mStoreOption->mEnableBufferCrcCheck && cooledBf.mHeader.mCrc) {
     LS_DCHECK(cooledBf.mPage.CRC() == cooledBf.mHeader.mCrc);
   }
   LS_DCHECK(!cooledBf.IsDirty());
@@ -377,7 +377,7 @@ void PageEvictor::evictFlushedBf(BufferFrame& cooledBf, BMOptimisticGuard& optim
   cooledBf.mHeader.mLatch.UnlockExclusively();
 
   mFreeBfList.PushFront(cooledBf);
-  if (mFreeBfList.Size() <= std::min<uint64_t>(mStore->mStoreOption.mWorkerThreads, 128)) {
+  if (mFreeBfList.Size() <= std::min<uint64_t>(mStore->mStoreOption->mWorkerThreads, 128)) {
     mFreeBfList.PopTo(targetPartition);
   }
 

--- a/src/concurrency/GroupCommitter.cpp
+++ b/src/concurrency/GroupCommitter.cpp
@@ -78,7 +78,7 @@ void GroupCommitter::collectWalRecords(uint64_t& minFlushedGSN, uint64_t& maxFlu
     // prepare IOCBs on demand
     const uint64_t buffered = reqCopy.mWalBuffered;
     const uint64_t flushed = logging.mWalFlushed;
-    const uint64_t bufferEnd = mStore->mStoreOption.mWalBufferSize;
+    const uint64_t bufferEnd = mStore->mStoreOption->mWalBufferSize;
     if (buffered > flushed) {
       append(logging.mWalBuffer, flushed, buffered);
     } else if (buffered < flushed) {
@@ -87,7 +87,7 @@ void GroupCommitter::collectWalRecords(uint64_t& minFlushedGSN, uint64_t& maxFlu
     }
   }
 
-  if (!mAIo.IsEmpty() && mStore->mStoreOption.mEnableWalFsync) {
+  if (!mAIo.IsEmpty() && mStore->mStoreOption->mEnableWalFsync) {
     mAIo.PrepareFsync(mWalFd);
   }
 }
@@ -110,7 +110,7 @@ void GroupCommitter::flushWalRecords() {
   }
 
   //! sync the metadata in the end.
-  if (mStore->mStoreOption.mEnableWalFsync) {
+  if (mStore->mStoreOption->mEnableWalFsync) {
     auto failed = fdatasync(mWalFd);
     if (failed) {
       Log::Error("fdatasync failed, errno={}, error={}", errno, strerror(errno));

--- a/src/concurrency/HistoryStorage.cpp
+++ b/src/concurrency/HistoryStorage.cpp
@@ -133,11 +133,11 @@ void HistoryStorage::PurgeVersions(TXID fromTxId, TXID toTxId,
                                    RemoveVersionCallback onRemoveVersion,
                                    [[maybe_unused]] const uint64_t limit) {
   auto keySize = sizeof(toTxId);
-  uint8_t keyBuffer[utils::tlsStore->mStoreOption.mPageSize];
+  uint8_t keyBuffer[utils::tlsStore->mStoreOption->mPageSize];
   utils::Fold(keyBuffer, fromTxId);
   Slice key(keyBuffer, keySize);
 
-  uint8_t payload[utils::tlsStore->mStoreOption.mPageSize];
+  uint8_t payload[utils::tlsStore->mStoreOption->mPageSize];
   uint16_t payloadSize;
   uint64_t versionsRemoved = 0;
 
@@ -299,12 +299,12 @@ void HistoryStorage::VisitRemovedVersions(TXID fromTxId, TXID toTxId,
                                           RemoveVersionCallback onRemoveVersion) {
   auto* removeTree = mRemoveIndex;
   auto keySize = sizeof(toTxId);
-  uint8_t keyBuffer[utils::tlsStore->mStoreOption.mPageSize];
+  uint8_t keyBuffer[utils::tlsStore->mStoreOption->mPageSize];
 
   uint64_t offset = 0;
   offset += utils::Fold(keyBuffer + offset, fromTxId);
   Slice key(keyBuffer, keySize);
-  uint8_t payload[utils::tlsStore->mStoreOption.mPageSize];
+  uint8_t payload[utils::tlsStore->mStoreOption->mPageSize];
   uint16_t payloadSize;
 
   JUMPMU_TRY() {

--- a/src/concurrency/Recovery.cpp
+++ b/src/concurrency/Recovery.cpp
@@ -58,7 +58,7 @@ Result<void> Recovery::analysis() {
   SCOPED_DEFER(Log::Info("[Recovery] analysis phase ends"))
 
   // asume that each WalEntry is smaller than the page size
-  utils::AlignedBuffer<512> alignedBuffer(mStore->mStoreOption.mPageSize);
+  utils::AlignedBuffer<512> alignedBuffer(mStore->mStoreOption->mPageSize);
   uint8_t* walEntryPtr = alignedBuffer.Get();
   for (auto offset = mWalStartOffset; offset < mWalSize;) {
     auto startOffset = offset;
@@ -109,7 +109,7 @@ Result<void> Recovery::redo() {
   SCOPED_DEFER(Log::Info("[Recovery] redo phase ends"))
 
   // asume that each WalEntry is smaller than the page size
-  utils::AlignedBuffer<512> alignedBuffer(mStore->mStoreOption.mPageSize);
+  utils::AlignedBuffer<512> alignedBuffer(mStore->mStoreOption->mPageSize);
   auto* complexEntry = reinterpret_cast<WalEntryComplex*>(alignedBuffer.Get());
 
   for (auto offset = mWalStartOffset; offset < mWalSize;) {
@@ -461,7 +461,7 @@ storage::BufferFrame& Recovery::resolvePage(PID pageId) {
 
 // TODO(zz-jason): refactor with aio
 Result<void> Recovery::readFromWalFile(int64_t offset, size_t nbytes, void* destination) {
-  auto fileName = mStore->mStoreOption.GetWalFilePath();
+  auto fileName = mStore->GetWalFilePath();
   FILE* fp = fopen(fileName.c_str(), "rb");
   if (fp == nullptr) {
     return std::unexpected(utils::Error::FileOpen(fileName, errno, strerror(errno)));

--- a/src/concurrency/Worker.cpp
+++ b/src/concurrency/Worker.cpp
@@ -31,7 +31,7 @@ Worker::Worker(uint64_t workerId, std::vector<Worker*>& allWorkers, leanstore::L
   CRCounters::MyCounters().mWorkerId = workerId;
 
   // init wal buffer
-  mLogging.mWalBufferSize = mStore->mStoreOption.mWalBufferSize;
+  mLogging.mWalBufferSize = mStore->mStoreOption->mWalBufferSize;
   mLogging.mWalBuffer = (uint8_t*)(std::aligned_alloc(512, mLogging.mWalBufferSize));
   std::memset(mLogging.mWalBuffer, 0, mLogging.mWalBufferSize);
 
@@ -95,7 +95,7 @@ void Worker::StartTx(TxMode mode, IsolationLevel level, bool isReadOnly) {
     mActiveTx.mStartTs = mStore->AllocTs();
   }
   auto curTxId = mActiveTx.mStartTs;
-  if (mStore->mStoreOption.mEnableLongRunningTx && mActiveTx.IsLongRunning()) {
+  if (mStore->mStoreOption->mEnableLongRunningTx && mActiveTx.IsLongRunning()) {
     // Mark as long-running transaction
     curTxId |= kLongRunningBit;
   }

--- a/src/leanstore-c/StoreOption.cpp
+++ b/src/leanstore-c/StoreOption.cpp
@@ -1,0 +1,99 @@
+#include "leanstore-c/StoreOption.h"
+
+#include <string.h>
+
+//! The default store option.
+static const StoreOption kDefaultStoreOption = {
+    // Store related options
+    .mCreateFromScratch = true,
+    .mStoreDir = "~/.leanstore",
+
+    // log related options
+    .mLogLevel = LogLevel::kInfo,
+
+    // Worker thread related options
+    .mWorkerThreads = 4,
+    .mWalBufferSize = 10 * 1024 * 1024,
+
+    // Buffer pool related options
+    .mPageSize = 4 * 1024,
+    .mBufferFrameSize = 512 + 4 * 1024,
+    .mNumPartitions = 64,
+    .mBufferPoolSize = 1ull * 1024 * 1024 * 1024,
+    .mFreePct = 1,
+    .mNumBufferProviders = 1,
+    .mBufferWriteBatchSize = 1024,
+    .mEnableBufferCrcCheck = false,
+    .mBufferFrameRecycleBatchSize = 64,
+    .mEnableReclaimPageIds = true,
+
+    // Logging and recovery related options
+    .mEnableWal = true,
+    .mEnableWalFsync = false,
+
+    // Generic BTree related options
+    .mEnableBulkInsert = false,
+    .mEnableXMerge = false,
+    .mXMergeK = 5,
+    .mXMergeTargetPct = 80,
+    .mEnableContentionSplit = true,
+    .mContentionSplitProbility = 14,
+    .mContentionSplitSampleProbability = 7,
+    .mContentionSplitThresholdPct = 1,
+    .mBTreeHints = 1,
+    .mEnableHeadOptimization = true,
+    .mEnableOptimisticScan = true,
+
+    // Transaction related options
+    .mEnableLongRunningTx = true,
+    .mEnableFatTuple = false,
+    .mEnableGc = true,
+    .mEnableEagerGc = false,
+
+    // Metrics related options
+    .mEnableMetrics = false,
+    .mMetricsPort = 8080,
+    .mEnableCpuCounters = true,
+    .mEnableTimeMeasure = false,
+    .mEnablePerfEvents = false,
+};
+
+StoreOption* CreateStoreOption(const char* storeDir) {
+  // create a new store option with default values
+  StoreOption* option = new StoreOption();
+  *option = kDefaultStoreOption;
+
+  if (storeDir == nullptr) {
+    storeDir = kDefaultStoreOption.mStoreDir;
+  }
+
+  // override the default store directory
+  char* storeDirCopy = new char[strlen(storeDir) + 1];
+  memcpy(storeDirCopy, storeDir, strlen(storeDir));
+  storeDirCopy[strlen(storeDir)] = '\0';
+  option->mStoreDir = storeDirCopy;
+
+  return option;
+}
+
+StoreOption* CreateStoreOptionFrom(const StoreOption* storeDir) {
+  StoreOption* option = new StoreOption();
+  *option = *storeDir;
+
+  // deep copy the store directory
+  char* storeDirCopy = new char[strlen(storeDir->mStoreDir) + 1];
+  memcpy(storeDirCopy, storeDir->mStoreDir, strlen(storeDir->mStoreDir));
+  storeDirCopy[strlen(storeDir->mStoreDir)] = '\0';
+  option->mStoreDir = storeDirCopy;
+
+  return option;
+}
+
+void DestroyStoreOption(const StoreOption* option) {
+  if (option != nullptr) {
+    if (option->mStoreDir != nullptr) {
+      delete[] option->mStoreDir;
+    }
+    delete option;
+  }
+}

--- a/src/profiling/counters/CPUCounters.cpp
+++ b/src/profiling/counters/CPUCounters.cpp
@@ -11,7 +11,7 @@ uint64_t CPUCounters::id = 0;
 std::unordered_map<uint64_t, CPUCounters> CPUCounters::threads;
 
 uint64_t CPUCounters::registerThread(std::string name, bool perfInherit) {
-  if (!utils::tlsStore->mStoreOption.mEnablePerfEvents) {
+  if (!utils::tlsStore->mStoreOption->mEnablePerfEvents) {
     return 0;
   }
 

--- a/src/profiling/tables/BMTable.cpp
+++ b/src/profiling/tables/BMTable.cpp
@@ -20,13 +20,13 @@ void BMTable::open() {
   columns.emplace("key", [](Column& col) { col << 0; });
 
   columns.emplace("space_usage_gib", [&](Column& col) {
-    const double gib = bm.ConsumedPages() * 1.0 * utils::tlsStore->mStoreOption.mPageSize / 1024.0 /
-                       1024.0 / 1024.0;
+    const double gib = bm.ConsumedPages() * 1.0 * utils::tlsStore->mStoreOption->mPageSize /
+                       1024.0 / 1024.0 / 1024.0;
     col << gib;
   });
 
   columns.emplace("space_usage_kib", [&](Column& col) {
-    const double kib = bm.ConsumedPages() * 1.0 * utils::tlsStore->mStoreOption.mPageSize / 1024.0;
+    const double kib = bm.ConsumedPages() * 1.0 * utils::tlsStore->mStoreOption->mPageSize / 1024.0;
     col << kib;
   });
 
@@ -52,7 +52,7 @@ void BMTable::open() {
   columns.emplace("free_pct", [&](Column& col) { col << (local_total_free * 100.0 / bm.mNumBfs); });
   columns.emplace("evicted_mib", [&](Column& col) {
     auto res = Sum(PPCounters::sCounters, &PPCounters::evicted_pages);
-    col << (res * utils::tlsStore->mStoreOption.mPageSize / 1024.0 / 1024.0);
+    col << (res * utils::tlsStore->mStoreOption->mPageSize / 1024.0 / 1024.0);
   });
   columns.emplace("rounds", [&](Column& col) {
     col << (Sum(PPCounters::sCounters, &PPCounters::pp_thread_rounds));
@@ -72,7 +72,7 @@ void BMTable::open() {
   });
   columns.emplace("w_mib", [&](Column& col) {
     auto res = Sum(PPCounters::sCounters, &PPCounters::flushed_pages_counter);
-    col << (res * utils::tlsStore->mStoreOption.mPageSize / 1024.0 / 1024.0);
+    col << (res * utils::tlsStore->mStoreOption->mPageSize / 1024.0 / 1024.0);
   });
 
   columns.emplace("allocate_ops", [&](Column& col) {
@@ -80,7 +80,7 @@ void BMTable::open() {
   });
   columns.emplace("r_mib", [&](Column& col) {
     auto res = Sum(WorkerCounters::sCounters, &WorkerCounters::read_operations_counter);
-    col << (res * utils::tlsStore->mStoreOption.mPageSize / 1024.0 / 1024.0);
+    col << (res * utils::tlsStore->mStoreOption->mPageSize / 1024.0 / 1024.0);
   });
 }
 

--- a/src/profiling/tables/ConfigsTable.cpp
+++ b/src/profiling/tables/ConfigsTable.cpp
@@ -16,70 +16,70 @@ void ConfigsTable::add(std::string name, std::string value) {
 
 void ConfigsTable::open() {
   columns.emplace("c_worker_threads",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mWorkerThreads; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mWorkerThreads; });
 
   columns.emplace("c_free_pct",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mFreePct; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mFreePct; });
 
   columns.emplace("c_buffer_frame_providers",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mNumBufferProviders; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mNumBufferProviders; });
 
   columns.emplace("c_num_partitions",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mNumPartitions; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mNumPartitions; });
 
   columns.emplace("c_buffer_pool_size",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mBufferPoolSize; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mBufferPoolSize; });
 
   columns.emplace("c_bulk_insert",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableBulkInsert; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableBulkInsert; });
 
   columns.emplace("c_contention_split", [&](Column& col) {
-    col << utils::tlsStore->mStoreOption.mEnableContentionSplit;
+    col << utils::tlsStore->mStoreOption->mEnableContentionSplit;
   });
 
   columns.emplace("c_contention_split_sample_probability", [&](Column& col) {
-    col << utils::tlsStore->mStoreOption.mContentionSplitSampleProbability;
+    col << utils::tlsStore->mStoreOption->mContentionSplitSampleProbability;
   });
 
   columns.emplace("c_cm_period", [&](Column& col) {
-    col << utils::tlsStore->mStoreOption.mContentionSplitProbility;
+    col << utils::tlsStore->mStoreOption->mContentionSplitProbility;
   });
 
   columns.emplace("c_contention_split_threshold_pct", [&](Column& col) {
-    col << utils::tlsStore->mStoreOption.mContentionSplitThresholdPct;
+    col << utils::tlsStore->mStoreOption->mContentionSplitThresholdPct;
   });
 
   columns.emplace("c_xmerge",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableXMerge; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableXMerge; });
 
   columns.emplace("c_xmerge_k",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mXMergeK; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mXMergeK; });
 
   columns.emplace("c_xmerge_target_pct",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mXMergeTargetPct; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mXMergeTargetPct; });
 
   columns.emplace("c_btree_heads", [&](Column& col) {
-    col << utils::tlsStore->mStoreOption.mEnableHeadOptimization;
+    col << utils::tlsStore->mStoreOption->mEnableHeadOptimization;
   });
 
   columns.emplace("c_btree_hints",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mBTreeHints; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mBTreeHints; });
 
-  columns.emplace("c_wal", [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableWal; });
+  columns.emplace("c_wal", [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableWal; });
 
   columns.emplace("c_wal_io_hack", [&](Column& col) { col << 1; });
 
   columns.emplace("c_wal_fsync",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableWalFsync; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableWalFsync; });
 
   columns.emplace("c_enable_garbage_collection",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableGc; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableGc; });
 
   columns.emplace("c_vi_fat_tuple",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableFatTuple; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableFatTuple; });
 
   columns.emplace("c_enable_long_running_transaction",
-                  [&](Column& col) { col << utils::tlsStore->mStoreOption.mEnableLongRunningTx; });
+                  [&](Column& col) { col << utils::tlsStore->mStoreOption->mEnableLongRunningTx; });
 
   for (auto& c : columns) {
     c.second.generator(c.second);

--- a/src/telemetry/MetricsHttpExposer.cpp
+++ b/src/telemetry/MetricsHttpExposer.cpp
@@ -6,7 +6,7 @@ namespace leanstore::telemetry {
 
 MetricsHttpExposer::MetricsHttpExposer(LeanStore* store)
     : UserThread(store, "MetricsExposer"),
-      mPort(mStore->mStoreOption.mMetricsPort) {
+      mPort(mStore->mStoreOption->mMetricsPort) {
   mServer.new_task_queue = [] { return new httplib::ThreadPool(1); };
   mServer.Get("/metrics", [&](const httplib::Request& req, httplib::Response& res) {
     handleMetrics(req, res);

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -12,14 +12,16 @@
 
 namespace leanstore {
 
-void Log::Init(const StoreOption& option) {
+void Log::Init(const StoreOption* option) {
   if (sInited) {
     return;
   }
 
   std::unique_lock writeLock(sInitMutex);
 
-  auto logger = spdlog::basic_logger_mt("basic_logger", option.GetLogPath());
+  auto logPath = std::string(option->mStoreDir) + "/db.log";
+  auto logger = spdlog::basic_logger_mt("basic_logger", logPath.c_str());
+
   SCOPED_DEFER({
     spdlog::set_default_logger(logger);
     spdlog::flush_every(std::chrono::seconds(3));
@@ -33,7 +35,7 @@ void Log::Init(const StoreOption& option) {
   logger->flush_on(spdlog::level::info);
 
   // set log level
-  switch (option.mLogLevel) {
+  switch (option->mLogLevel) {
   case LogLevel::kDebug: {
     logger->set_level(spdlog::level::debug);
     break;
@@ -51,7 +53,7 @@ void Log::Init(const StoreOption& option) {
     break;
   }
   default: {
-    std::cerr << std::format("unsupported log level: {}", static_cast<uint8_t>(option.mLogLevel));
+    std::cerr << std::format("unsupported log level: {}", static_cast<uint8_t>(option->mLogLevel));
     std::abort();
   }
   }

--- a/src/utils/Misc.cpp
+++ b/src/utils/Misc.cpp
@@ -12,13 +12,13 @@ uint32_t CRC(const uint8_t* src, uint64_t size) {
 }
 
 Timer::Timer(std::atomic<uint64_t>& timeCounterUS) : mTimeCounterUS(timeCounterUS) {
-  if (tlsStore->mStoreOption.mEnableTimeMeasure) {
+  if (tlsStore->mStoreOption->mEnableTimeMeasure) {
     mStartTimePoint = std::chrono::high_resolution_clock::now();
   }
 }
 
 Timer::~Timer() {
-  if (tlsStore->mStoreOption.mEnableTimeMeasure) {
+  if (tlsStore->mStoreOption->mEnableTimeMeasure) {
     auto endTimePoint = std::chrono::high_resolution_clock::now();
     const uint64_t duration =
         std::chrono::duration_cast<std::chrono::microseconds>(endTimePoint - mStartTimePoint)

--- a/tests/BasicKVTest.cpp
+++ b/tests/BasicKVTest.cpp
@@ -1,7 +1,7 @@
 #include "leanstore/btree/BasicKV.hpp"
 
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/btree/TransactionKV.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
 #include "leanstore/concurrency/CRManager.hpp"
@@ -23,18 +23,19 @@ protected:
 
   void SetUp() override {
     // Create a leanstore instance for the test case
-    auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
-    auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
-
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mWorkerThreads = 2,
-        .mEnableBulkInsert = false,
-        .mEnableEagerGc = true,
-    });
+    StoreOption* option = CreateStoreOption(getTestDataDir().c_str());
+    option->mWorkerThreads = 2;
+    option->mEnableEagerGc = true;
+    auto res = LeanStore::Open(option);
     ASSERT_TRUE(res);
+
     mStore = std::move(res.value());
+  }
+
+private:
+  std::string getTestDataDir() {
+    auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
+    return std::string("/tmp/leanstore/") + curTest->test_case_name() + "_" + curTest->name();
   }
 };
 

--- a/tests/LongRunningTxTest.cpp
+++ b/tests/LongRunningTxTest.cpp
@@ -1,6 +1,6 @@
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/KVInterface.hpp"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/btree/BasicKV.hpp"
 #include "leanstore/btree/TransactionKV.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
@@ -35,13 +35,14 @@ protected:
     // Create a leanstore instance for the test case
     auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
     auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
+    auto storeDirStr = std::string("/tmp/") + curTestName;
 
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mWorkerThreads = 3,
-        .mEnableEagerGc = true,
-    });
+    StoreOption* option = CreateStoreOption(storeDirStr.c_str());
+    option->mCreateFromScratch = true;
+    option->mWorkerThreads = 3;
+    option->mEnableEagerGc = true;
+
+    auto res = LeanStore::Open(option);
     ASSERT_TRUE(res);
     mStore = std::move(res.value());
 

--- a/tests/MvccTest.cpp
+++ b/tests/MvccTest.cpp
@@ -1,5 +1,5 @@
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/btree/BasicKV.hpp"
 #include "leanstore/btree/TransactionKV.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
@@ -27,11 +27,11 @@ protected:
   MvccTest() {
     auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
     auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mWorkerThreads = 3,
-    });
+    auto storeDirStr = "/tmp/" + curTestName;
+    StoreOption* option = CreateStoreOption(storeDirStr.c_str());
+    option->mCreateFromScratch = true;
+    option->mWorkerThreads = 3;
+    auto res = LeanStore::Open(option);
     mStore = std::move(res.value());
   }
 

--- a/tests/OptimisticGuardedTest.cpp
+++ b/tests/OptimisticGuardedTest.cpp
@@ -1,7 +1,7 @@
 #include "leanstore/sync/OptimisticGuarded.hpp"
 
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
 #include "leanstore/concurrency/CRManager.hpp"
 
@@ -26,12 +26,11 @@ protected:
   void SetUp() override {
     auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
     auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mWorkerThreads = 2,
-    });
-
+    auto storeDirStr = "/tmp/" + curTestName;
+    auto* option = CreateStoreOption(storeDirStr.c_str());
+    option->mCreateFromScratch = true;
+    option->mWorkerThreads = 2;
+    auto res = LeanStore::Open(option);
     ASSERT_TRUE(res);
     mStore = std::move(res.value());
   }

--- a/tests/TransactionKVTest.cpp
+++ b/tests/TransactionKVTest.cpp
@@ -1,13 +1,11 @@
 #include "leanstore/btree/TransactionKV.hpp"
 
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/KVInterface.hpp"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
-#include "leanstore/btree/core/BTreeGeneric.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
 #include "leanstore/concurrency/CRManager.hpp"
 #include "leanstore/utils/Defer.hpp"
-#include "leanstore/utils/JsonUtil.hpp"
 #include "leanstore/utils/Log.hpp"
 #include "leanstore/utils/RandomGenerator.hpp"
 
@@ -33,12 +31,11 @@ protected:
   TransactionKVTest() {
     auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
     auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mWorkerThreads = 3,
-        .mEnableEagerGc = true,
-    });
+    auto* option = CreateStoreOption(("/tmp/" + curTestName).c_str());
+    option->mCreateFromScratch = true;
+    option->mWorkerThreads = 3;
+    option->mEnableEagerGc = true;
+    auto res = LeanStore::Open(option);
     mStore = std::move(res.value());
   }
 

--- a/tests/TxKV.hpp
+++ b/tests/TxKV.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/KVInterface.hpp"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/Units.hpp"
 #include "leanstore/btree/TransactionKV.hpp"
 #include "leanstore/concurrency/CRManager.hpp"
@@ -89,11 +89,9 @@ public:
 
 public:
   LeanStoreMVCC(const std::string& storeDir, uint32_t sessionLimit) {
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = storeDir,
-        .mWorkerThreads = sessionLimit,
-    });
+    StoreOption* option = CreateStoreOption(storeDir.c_str());
+    option->mWorkerThreads = sessionLimit;
+    auto res = LeanStore::Open(option);
     mLeanStore = std::move(res.value());
   }
 

--- a/tests/btree/BasicKvIteratorTest.cpp
+++ b/tests/btree/BasicKvIteratorTest.cpp
@@ -1,4 +1,5 @@
-#include "leanstore/leanstore-c.h"
+#include "leanstore-c/StoreOption.h"
+#include "leanstore-c/leanstore-c.h"
 
 #include <gtest/gtest.h>
 
@@ -14,7 +15,12 @@ protected:
   BasicKvHandle* mKvHandle;
 
   void SetUp() override {
-    mStoreHandle = CreateLeanStore(1, "/tmp/leanstore/examples/BasicKvExample", 2, 0, 1);
+    StoreOption* option = CreateStoreOption("/tmp/leanstore/examples/BasicKvExample");
+    option->mCreateFromScratch = true;
+    option->mWorkerThreads = 2;
+    option->mEnableBulkInsert = false;
+    option->mEnableEagerGc = true;
+    mStoreHandle = CreateLeanStore(option);
     ASSERT_NE(mStoreHandle, nullptr);
 
     mKvHandle = CreateBasicKV(mStoreHandle, 0, "testTree1");

--- a/tests/buffer-manager/PageEvictorTest.cpp
+++ b/tests/buffer-manager/PageEvictorTest.cpp
@@ -1,23 +1,10 @@
 #include "leanstore/buffer-manager/PageEvictor.hpp"
 
-#include "leanstore/buffer-manager/AsyncWriteBuffer.hpp"
-#include "leanstore/buffer-manager/BufferFrame.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
-#include "leanstore/buffer-manager/Swip.hpp"
-#include "leanstore/utils/Defer.hpp"
-#include "leanstore/utils/Log.hpp"
-#include "leanstore/utils/Misc.hpp"
-#include "leanstore/utils/RandomGenerator.hpp"
 
 #include <gtest/gtest.h>
 
-#include <cstddef>
-#include <cstdint>
 #include <cstring>
-#include <format>
-#include <iostream>
-
-#include <fcntl.h>
 
 namespace leanstore::storage::test {
 class PageEvictorTest : public ::testing::Test {
@@ -33,18 +20,17 @@ protected:
     auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
     const int pageSize = 4096;
     const int pageHeaderSize = 512;
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mLogLevel = LogLevel::kDebug,
-        .mWorkerThreads = 2,
-        .mNumPartitions = 1,
-        .mBufferPoolSize = 70 * (pageHeaderSize + pageSize),
-        .mFreePct = 20,
-        .mEnableBulkInsert = false,
-        .mEnableEagerGc = false,
-
-    });
+    auto storeDirStr = "/tmp/" + curTestName;
+    auto* option = CreateStoreOption(storeDirStr.c_str());
+    option->mCreateFromScratch = true;
+    option->mLogLevel = LogLevel::kDebug;
+    option->mWorkerThreads = 2;
+    option->mNumPartitions = 1;
+    option->mBufferPoolSize = 70 * (pageHeaderSize + pageSize);
+    option->mFreePct = 20;
+    option->mEnableBulkInsert = false;
+    option->mEnableEagerGc = false;
+    auto res = LeanStore::Open(option);
     ASSERT_TRUE(res);
     mStore = std::move(res.value());
   }

--- a/tests/sync/ScopedHybridGuardTest.cpp
+++ b/tests/sync/ScopedHybridGuardTest.cpp
@@ -1,7 +1,7 @@
 #include "leanstore/sync/ScopedHybridGuard.hpp"
 
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 #include "leanstore/buffer-manager/BufferManager.hpp"
 #include "leanstore/concurrency/CRManager.hpp"
 #include "leanstore/sync/HybridLatch.hpp"
@@ -28,12 +28,11 @@ protected:
   ScopedHybridGuardTest() {
     auto* curTest = ::testing::UnitTest::GetInstance()->current_test_info();
     auto curTestName = std::string(curTest->test_case_name()) + "_" + std::string(curTest->name());
-    auto res = LeanStore::Open(StoreOption{
-        .mCreateFromScratch = true,
-        .mStoreDir = "/tmp/" + curTestName,
-        .mWorkerThreads = 2,
-        .mEnableEagerGc = true,
-    });
+    auto* option = CreateStoreOption(("/tmp/" + curTestName).c_str());
+    option->mCreateFromScratch = true;
+    option->mWorkerThreads = 2;
+    option->mEnableEagerGc = true;
+    auto res = LeanStore::Open(option);
     mStore = std::move(res.value());
   }
 

--- a/tests/telemetry/MetricsManagerTest.cpp
+++ b/tests/telemetry/MetricsManagerTest.cpp
@@ -1,7 +1,7 @@
 #include "telemetry/MetricsManager.hpp"
 
+#include "leanstore-c/StoreOption.h"
 #include "leanstore/LeanStore.hpp"
-#include "leanstore/StoreOption.hpp"
 
 #include <gtest/gtest.h>
 #include <httplib.h>
@@ -20,16 +20,15 @@ protected:
 };
 
 TEST_F(MetricsManagerTest, Basic) {
-  auto res = leanstore::LeanStore::Open(StoreOption{
-      .mEnableMetrics = true,
-  });
+  auto* option = CreateStoreOption("/tmp/leanstore/MetricsManagerTest");
+  option->mEnableMetrics = true;
+  auto res = leanstore::LeanStore::Open(option);
   ASSERT_TRUE(res);
 
   auto store = std::move(res.value());
   METRIC_COUNTER_INC(store->mMetricsManager, tx_abort_total, 100);
 
-  httplib::Client cli("0.0.0.0", store->mStoreOption.mMetricsPort);
-
+  httplib::Client cli("0.0.0.0", store->mStoreOption->mMetricsPort);
   auto result = cli.Get("/metrics");
   ASSERT_TRUE(result) << "Error: " << result.error();
   ASSERT_EQ(result->status, httplib::StatusCode::OK_200) << "HTTP status: " << result->status;


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

Ref to https://github.com/zz-jason/leanstore/issues/97, Expose StoreOption to c API:
- `StoreOption` is created by the user before creating/open a LeanStore. `StoreOption`'s ownership is transferred to the created LeanStore if success, otherwise, users should handle the store creation error and destroy the StoreOption themselves.
- Move all c API related include/source files to `include/leanstore-c` and `src/leanstore-c`