### PR TITLE
chore: enable multi job senders for a worker thread

### DIFF
--- a/src/LeanStore.cpp
+++ b/src/LeanStore.cpp
@@ -156,9 +156,6 @@ LeanStore::~LeanStore() {
     Log::Info("LeanStore stopped");
   });
 
-  // wait all concurrent jobs to finsh
-  WaitAll();
-
   // print trees
   for (auto& it : mTreeRegistry->mTrees) {
     auto treeId = it.first;

--- a/tests/OptimisticGuardedTest.cpp
+++ b/tests/OptimisticGuardedTest.cpp
@@ -59,9 +59,6 @@ TEST_F(OptimisticGuardedTest, Set) {
       }
     }
   });
-
-  // Wait for all jobs to finish
-  mStore->WaitAll();
 }
 
 TEST_F(OptimisticGuardedTest, UpdateAttribute) {
@@ -87,9 +84,6 @@ TEST_F(OptimisticGuardedTest, UpdateAttribute) {
       }
     }
   });
-
-  // Wait for all jobs to finish
-  mStore->WaitAll();
 }
 
 } // namespace leanstore::test


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

Previously, a worker thread only supported exactly one job sender, which hurts the usability.  This PR enables multiple job sends for a single worker.