### PR TITLE
perf: improve ycsb performance

### DIFF
--- a/include/leanstore/concurrency/ConcurrencyControl.hpp
+++ b/include/leanstore/concurrency/ConcurrencyControl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "leanstore/LeanStore.hpp"
+#include "leanstore/Slice.hpp"
 #include "leanstore/Units.hpp"
 #include "leanstore/concurrency/HistoryStorage.hpp"
 #include "leanstore/profiling/counters/CRCounters.hpp"
@@ -193,11 +194,12 @@ public:
   //! @param getCallback: the callback function to be called when the version is found.
   //! @return: true if the version is found, false otherwise.
   inline bool GetVersion(WORKERID newerWorkerId, TXID newerTxId, COMMANDID newerCommandId,
-                         std::function<void(const uint8_t*, uint64_t versionSize)> getCallback) {
+                         std::function<void(Slice)> versionCallback) {
     utils::Timer timer(CRCounters::MyCounters().cc_ms_history_tree_retrieve);
     auto isRemoveCommand = newerCommandId & kRemoveCommandMark;
     return Other(newerWorkerId)
-        .mHistoryStorage.GetVersion(newerTxId, newerCommandId, isRemoveCommand, getCallback);
+        .mHistoryStorage.GetVersion(newerTxId, newerCommandId, isRemoveCommand,
+                                    std::move(versionCallback));
   }
 
   //! Put a version to the version storage. The callback function is called with the version data

--- a/include/leanstore/concurrency/HistoryStorage.hpp
+++ b/include/leanstore/concurrency/HistoryStorage.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "leanstore/Slice.hpp"
 #include "leanstore/Units.hpp"
 
 #include <cstdint>
@@ -88,7 +89,7 @@ public:
                   uint64_t payloadLength, std::function<void(uint8_t*)> cb, bool sameThread = true);
 
   bool GetVersion(TXID newerTxId, COMMANDID newerCommandId, const bool isRemoveCommand,
-                  std::function<void(const uint8_t*, uint64_t)> cb);
+                  std::function<void(Slice)> cb);
 
   void PurgeVersions(TXID fromTxId, TXID toTxId, RemoveVersionCallback cb, const uint64_t limit);
 

--- a/include/leanstore/concurrency/Logging.hpp
+++ b/include/leanstore/concurrency/Logging.hpp
@@ -57,19 +57,11 @@ public:
   //! processing.
   WalEntryComplex* mActiveWALEntryComplex;
 
-  //! Protects mTxToCommit
-  std::mutex mTxToCommitMutex;
+  //! The pending-to-commit transactions which have remote dependencies.
+  std::atomic<Transaction*> mActiveTxToCommit;
 
-  //! The queue for each worker thread to store pending-to-commit transactions which have remote
-  //! dependencies.
-  std::vector<Transaction> mTxToCommit;
-
-  //! Protects mTxToCommit
-  std::mutex mRfaTxToCommitMutex;
-
-  //! The queue for each worker thread to store pending-to-commit transactions which doesn't have
-  //! any remote dependencies.
-  std::vector<Transaction> mRfaTxToCommit;
+  //! The pending-to-commit transactions which doesn't have any remote dependencies.
+  std::atomic<Transaction*> mActiveRfaTxToCommit;
 
   //! Represents the maximum commit timestamp in the worker. Transactions in the worker are
   //! committed if their commit timestamps are smaller than it.
@@ -137,8 +129,7 @@ private:
 
   void publishWalFlushReq();
 
-  //! Calculate the continuous free space left in the wal ring buffer. Return
-  //! size of the contiguous free space.
+  //! Continuous free space left in the wal ring buffer.
   uint32_t walContiguousFreeSpace();
 };
 

--- a/src/btree/ChainedTuple.cpp
+++ b/src/btree/ChainedTuple.cpp
@@ -33,8 +33,9 @@ std::tuple<OpCode, uint16_t> ChainedTuple::GetVisibleTuple(Slice payload,
   uint16_t versionsRead = 1;
   while (true) {
     bool found = cr::WorkerContext::My().mCc.GetVersion(
-        newerWorkerId, newerTxId, newerCommandId,
-        [&](const uint8_t* versionBuf, uint64_t versionSize) {
+        newerWorkerId, newerTxId, newerCommandId, [&](Slice versionSlice) {
+          auto* versionBuf = versionSlice.data();
+          auto versionSize = versionSlice.size();
           auto& version = *reinterpret_cast<const Version*>(versionBuf);
           switch (version.mType) {
           case VersionType::kUpdate: {

--- a/src/btree/TransactionKV.cpp
+++ b/src/btree/TransactionKV.cpp
@@ -278,12 +278,12 @@ std::tuple<OpCode, uint16_t> TransactionKV::getVisibleTuple(Slice payload, ValCa
       switch (tuple->mFormat) {
       case TupleFormat::kChained: {
         const auto* const chainedTuple = ChainedTuple::From(payload.data());
-        ret = chainedTuple->GetVisibleTuple(payload, callback);
+        ret = chainedTuple->GetVisibleTuple(payload, std::move(callback));
         JUMPMU_RETURN ret;
       }
       case TupleFormat::kFat: {
         const auto* const fatTuple = FatTuple::From(payload.data());
-        ret = fatTuple->GetVisibleTuple(callback);
+        ret = fatTuple->GetVisibleTuple(std::move(callback));
         JUMPMU_RETURN ret;
       }
       default: {

--- a/src/btree/Tuple.cpp
+++ b/src/btree/Tuple.cpp
@@ -70,9 +70,9 @@ bool Tuple::ToFat(PessimisticExclusiveIterator& xIter) {
     }
 
     if (!cr::WorkerContext::My().mCc.GetVersion(
-            newerWorkerId, newerTxId, newerCommandId, [&](const uint8_t* version, uint64_t) {
+            newerWorkerId, newerTxId, newerCommandId, [&](Slice version) {
               numDeltasToReplace++;
-              const auto& chainedDelta = *UpdateVersion::From(version);
+              const auto& chainedDelta = *UpdateVersion::From(version.data());
               LS_DCHECK(chainedDelta.mType == VersionType::kUpdate);
               LS_DCHECK(chainedDelta.mIsDelta);
 

--- a/src/concurrency/WorkerContext.cpp
+++ b/src/concurrency/WorkerContext.cpp
@@ -127,11 +127,9 @@ void WorkerContext::CommitTx() {
 
   // for group commit
   if (mActiveTx.mHasRemoteDependency) {
-    std::unique_lock<std::mutex> g(mLogging.mTxToCommitMutex);
-    mLogging.mTxToCommit.push_back(mActiveTx);
+    mLogging.mActiveTxToCommit.store(&mActiveTx);
   } else {
-    std::unique_lock<std::mutex> g(mLogging.mRfaTxToCommitMutex);
-    mLogging.mRfaTxToCommit.push_back(mActiveTx);
+    mLogging.mActiveRfaTxToCommit.store(&mActiveTx);
   }
 
   // Cleanup versions in history tree


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

- use atomic value to store active transactions with or without remote dependency
- eliminate std::function converting overhead

ycsb workload b improved from 3909261 to 4630909, ~18.46%