### PR TITLE
fix: hang on ycsb workload b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   ut_coverage:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
       image: zzjason/leanstore-dev:latest
-    name: Unit Tests - Coverage
+    name: Unit Tests && Code Coverage
     steps:
     - name: Check out repository
       uses: actions/checkout@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker
+          file: ./Dockerfile
+          push: true
+          tags: zzjason/leanstore-dev:latest

--- a/benchmarks/ycsb/ycsb_leanstore.hpp
+++ b/benchmarks/ycsb/ycsb_leanstore.hpp
@@ -53,7 +53,7 @@ public:
     StoreOption* option = CreateStoreOption(datadir_str.c_str());
     option->create_from_scratch_ = create_from_scratch;
     option->enable_eager_gc_ = true;
-    option->enable_wal_ = false;
+    option->enable_wal_ = true;
     option->worker_threads_ = FLAGS_ycsb_threads;
     option->buffer_pool_size_ = FLAGS_ycsb_mem_gb << 30;
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+
+  node_exporter:
+    image: prom/node-exporter:latest
+    container_name: node_exporter
+    ports:
+      - "9100:9100"
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+      - '--collector.filesystem.ignored-mount-points=^(sys|proc|dev|host|etc)($|/)'
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+
+volumes:
+  grafana-storage:
+  prometheus_data:

--- a/docker/compose/prometheus.yml
+++ b/docker/compose/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node_exporter:9100']

--- a/src/utils/coroutine/coro_scheduler.hpp
+++ b/src/utils/coroutine/coro_scheduler.hpp
@@ -107,8 +107,8 @@ inline std::shared_ptr<CoroFuture<R>> CoroScheduler::Submit(F&& coro_func, int64
       future->SetResult(std::move(result));
     }
   };
-
   coro_executors_[thread_id]->EnqueueCoro(std::make_unique<Coroutine>(std::move(coro_job)));
+
   return coro_future;
 }
 


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

This pull request introduces several significant updates, including enabling write-ahead logging (WAL) in the YCSB benchmark, integrating a monitoring stack with Prometheus and Grafana, and adding coroutine support for concurrency mechanisms. Below is a categorized summary of the most important changes:

### Benchmark Configuration Updates:
* Enabled write-ahead logging (WAL) in the `YcsbLeanStore` class by setting `option->enable_wal_` to `true`, improving durability for the YCSB benchmark. (`benchmarks/ycsb/ycsb_leanstore.hpp`, [benchmarks/ycsb/ycsb_leanstore.hppL56-R56](diffhunk://#diff-1ee0276e80b0e7fc8d2c8332a32c4a7eae62a844cd5743af3bde5f77a84bc346L56-R56))

### Monitoring Stack Integration:
* Added Prometheus, Node Exporter, and Grafana services to the `docker-compose.yml` file to enable system monitoring and visualization. (`docker/compose/docker-compose.yml`, [docker/compose/docker-compose.ymlR1-R41](diffhunk://#diff-9aa277adb3532fde7e800578571f7461375cc6192777ed2a324549b73bbd0078R1-R41))
* Configured Prometheus to scrape metrics from the Node Exporter every 15 seconds by adding a `prometheus.yml` configuration file. (`docker/compose/prometheus.yml`, [docker/compose/prometheus.ymlR1-R7](diffhunk://#diff-031a091dd4052bf4c7cc440f5ac6f724bd7b8847fba7dc74c5fa3115d7e6efa4R1-R7))

### Coroutine Enhancements:
* Introduced coroutine support in the `HybridGuard` class, enabling coroutines to yield and retry optimistic locking when contention is detected. (`include/leanstore/sync/hybrid_guard.hpp`, [include/leanstore/sync/hybrid_guard.hppL102-R118](diffhunk://#diff-beebf7bffaa7276bbb5a13fdd157c705cc43fd5bfc3497d09dc6c949f24c0b4bL102-R118))
* Added coroutine-related headers and logic to the `Logging::ReserveContiguousBuffer` method, allowing coroutines to yield during I/O waits for WAL operations. (`src/concurrency/logging.cpp`, [[1]](diffhunk://#diff-228ed9c6af588e1c80eba3a0b92a82de6337713699117e703afd7b6e0131ee45R32-R34) [[2]](diffhunk://#diff-228ed9c6af588e1c80eba3a0b92a82de6337713699117e703afd7b6e0131ee45R43-R45)
* Made a minor adjustment in `CoroScheduler::Submit` to improve coroutine job submission. (`src/utils/coroutine/coro_scheduler.hpp`, [src/utils/coroutine/coro_scheduler.hppL110-R111](diffhunk://#diff-009d1fe455eb4d4d3d160c79fc59dc1e84bc0d0c36a7ddc5b452b9c0c9585e9cL110-R111))