### PR TITLE
chore: access TxManagers via CoroEnv

### DIFF
--- a/benchmarks/ycsb/ycsb_leanstore.hpp
+++ b/benchmarks/ycsb/ycsb_leanstore.hpp
@@ -162,7 +162,7 @@ public:
           utils::RandomGenerator::RandString(val, FLAGS_ycsb_val_size);
 
           if (bench_transaction_kv_) {
-            cr::TxManager::My().StartTx();
+            CoroEnv::CurTxMgr().StartTx();
           }
 
           auto op_code =
@@ -172,7 +172,7 @@ public:
           }
 
           if (bench_transaction_kv_) {
-            cr::TxManager::My().CommitTx();
+            CoroEnv::CurTxMgr().CommitTx();
           }
         }
       };
@@ -252,10 +252,10 @@ public:
                 // generate key for read
                 GenYcsbKey(zipf_random, key);
                 if (bench_transaction_kv_) {
-                  cr::TxManager::My().StartTx(TxMode::kShortRunning,
+                  CoroEnv::CurTxMgr().StartTx(TxMode::kShortRunning,
                                               IsolationLevel::kSnapshotIsolation, true);
                   table->Lookup(Slice(key, FLAGS_ycsb_key_size), copy_value);
-                  cr::TxManager::My().CommitTx();
+                  CoroEnv::CurTxMgr().CommitTx();
                 } else {
                   table->Lookup(Slice(key, FLAGS_ycsb_key_size), copy_value);
                 }
@@ -264,10 +264,10 @@ public:
                 GenYcsbKey(zipf_random, key);
                 // generate val for update
                 if (bench_transaction_kv_) {
-                  cr::TxManager::My().StartTx();
+                  CoroEnv::CurTxMgr().StartTx();
                   table->UpdatePartial(Slice(key, FLAGS_ycsb_key_size), update_call_back,
                                        *update_desc);
-                  cr::TxManager::My().CommitTx();
+                  CoroEnv::CurTxMgr().CommitTx();
                 } else {
                   table->UpdatePartial(Slice(key, FLAGS_ycsb_key_size), update_call_back,
                                        *update_desc);

--- a/include/leanstore-c/store_option.h
+++ b/include/leanstore-c/store_option.h
@@ -42,6 +42,9 @@ typedef struct StoreOption {
   /// The number of worker threads.
   uint64_t worker_threads_;
 
+  /// Maximum number of concurrent transactions per worker thread.
+  uint64_t max_concurrent_tx_per_worker_;
+
   // ---------------------------------------------------------------------------
   // Buffer pool related options
   // ---------------------------------------------------------------------------

--- a/include/leanstore/btree/core/b_tree_node.hpp
+++ b/include/leanstore/btree/core/b_tree_node.hpp
@@ -471,7 +471,7 @@ public:
   }
 
   static uint16_t Size() {
-    return static_cast<uint16_t>(utils::tls_store->store_option_->page_size_ - sizeof(Page));
+    return static_cast<uint16_t>(CoroEnv::CurStore()->store_option_->page_size_ - sizeof(Page));
   }
 
   static uint16_t UnderFullSize() {
@@ -556,7 +556,7 @@ inline int16_t BTreeNode::LowerBound(Slice key, bool* is_equal) {
   SearchHint(key_head, lower, upper);
   while (lower < upper) {
     bool found_equal(false);
-    if (utils::tls_store->store_option_->enable_head_optimization_) {
+    if (CoroEnv::CurStore()->store_option_->enable_head_optimization_) {
       found_equal = shrink_search_range_with_head(lower, upper, key, key_head);
     } else {
       found_equal = shrink_search_range(lower, upper, key);

--- a/include/leanstore/btree/core/btree_iter_mut.hpp
+++ b/include/leanstore/btree/core/btree_iter_mut.hpp
@@ -135,15 +135,15 @@ public:
 
   /// Updates contention statistics after each slot modification on the page.
   void UpdateContentionStats() {
-    if (!utils::tls_store->store_option_->enable_contention_split_) {
+    if (!CoroEnv::CurStore()->store_option_->enable_contention_split_) {
       return;
     }
     const uint64_t random_number = utils::RandomGenerator::RandU64();
 
     // haven't met the contention stats update probability
     if ((random_number &
-         ((1ull << utils::tls_store->store_option_->contention_split_sample_probability_) - 1)) !=
-        0) {
+         ((1ull << CoroEnv::CurStore()->store_option_->contention_split_sample_probability_) -
+          1)) != 0) {
       return;
     }
     auto& contention_stats = guarded_leaf_.bf_->header_.contention_stats_;
@@ -155,13 +155,13 @@ public:
 
     // haven't met the contention split validation probability
     if ((random_number &
-         ((1ull << utils::tls_store->store_option_->contention_split_probility_) - 1)) != 0) {
+         ((1ull << CoroEnv::CurStore()->store_option_->contention_split_probility_) - 1)) != 0) {
       return;
     }
     auto contention_pct = contention_stats.ContentionPercentage();
     contention_stats.Reset();
     if (last_updated_slot != slot_id_ &&
-        contention_pct >= utils::tls_store->store_option_->contention_split_threshold_pct_ &&
+        contention_pct >= CoroEnv::CurStore()->store_option_->contention_split_threshold_pct_ &&
         guarded_leaf_->num_slots_ > 2) {
       int16_t split_slot = std::min<int16_t>(last_updated_slot, slot_id_);
       guarded_leaf_.unlock();

--- a/include/leanstore/btree/core/btree_iter_pessistic.hpp
+++ b/include/leanstore/btree/core/btree_iter_pessistic.hpp
@@ -337,7 +337,7 @@ inline void BTreeIterPessistic::Next() {
       func_clean_up_ = nullptr;
     }
 
-    if (utils::tls_store->store_option_->enable_optimistic_scan_ && leaf_pos_in_parent_ != -1) {
+    if (CoroEnv::CurStore()->store_option_->enable_optimistic_scan_ && leaf_pos_in_parent_ != -1) {
       JUMPMU_TRY() {
         if ((leaf_pos_in_parent_ + 1) <= guarded_parent_->num_slots_) {
           int32_t next_leaf_pos = leaf_pos_in_parent_ + 1;
@@ -435,7 +435,7 @@ inline void BTreeIterPessistic::Prev() {
       func_clean_up_ = nullptr;
     }
 
-    if (utils::tls_store->store_option_->enable_optimistic_scan_ && leaf_pos_in_parent_ != -1) {
+    if (CoroEnv::CurStore()->store_option_->enable_optimistic_scan_ && leaf_pos_in_parent_ != -1) {
       JUMPMU_TRY() {
         if ((leaf_pos_in_parent_ - 1) >= 0) {
           int32_t next_leaf_pos = leaf_pos_in_parent_ - 1;

--- a/include/leanstore/btree/transaction_kv.hpp
+++ b/include/leanstore/btree/transaction_kv.hpp
@@ -111,7 +111,7 @@ public:
   }
 
   inline static uint64_t ConvertToFatTupleThreshold() {
-    return cr::TxManager::My().store_->store_option_->worker_threads_;
+    return CoroEnv::CurTxMgr().store_->store_option_->worker_threads_;
   }
 
   /// Updates the value stored in FatTuple. The former newest version value is

--- a/include/leanstore/buffer-manager/buffer_frame.hpp
+++ b/include/leanstore/buffer-manager/buffer_frame.hpp
@@ -152,7 +152,7 @@ public:
 
 public:
   uint64_t CRC() {
-    return utils::CRC(payload_, utils::tls_store->store_option_->page_size_ - sizeof(Page));
+    return utils::CRC(payload_, CoroEnv::CurStore()->store_option_->page_size_ - sizeof(Page));
   }
 };
 

--- a/include/leanstore/concurrency/transaction.hpp
+++ b/include/leanstore/concurrency/transaction.hpp
@@ -88,7 +88,7 @@ public:
     tx_mode_ = mode;
     tx_isolation_level_ = level;
     has_wrote_ = false;
-    is_durable_ = utils::tls_store->store_option_->enable_wal_;
+    is_durable_ = CoroEnv::CurStore()->store_option_->enable_wal_;
     wal_exceed_buffer_ = false;
   }
 

--- a/include/leanstore/concurrency/wal_payload_handler.hpp
+++ b/include/leanstore/concurrency/wal_payload_handler.hpp
@@ -37,7 +37,7 @@ public:
 
 template <typename T>
 inline void WalPayloadHandler<T>::SubmitWal() {
-  cr::TxManager::My().logging_.SubmitWALEntryComplex(total_size_);
+  CoroEnv::CurTxMgr().logging_.SubmitWALEntryComplex(total_size_);
 }
 
 } // namespace leanstore::cr

--- a/include/leanstore/utils/managed_thread.hpp
+++ b/include/leanstore/utils/managed_thread.hpp
@@ -3,6 +3,7 @@
 #include "leanstore/utils/defer.hpp"
 #include "leanstore/utils/log.hpp"
 #include "leanstore/utils/misc.hpp"
+#include "utils/coroutine/coro_env.hpp"
 
 #include <atomic>
 #include <memory>
@@ -19,7 +20,6 @@ class LeanStore;
 
 namespace leanstore::utils {
 
-inline thread_local LeanStore* tls_store = nullptr;
 inline thread_local std::string tls_thread_name = "";
 
 /// User thread with custom thread name.
@@ -74,7 +74,7 @@ public:
 
 protected:
   void Run() {
-    tls_store = store_;
+    CoroEnv::SetCurStore(store_);
 
     // set thread-local thread name at the very beging so that logs printed by
     // the thread can get it.

--- a/src/btree/basic_kv.cpp
+++ b/src/btree/basic_kv.cpp
@@ -161,13 +161,13 @@ OpCode BasicKV::Insert(Slice key, Slice val) {
     auto ret = x_iter->InsertKV(key, val);
 
     if (ret == OpCode::kDuplicated) {
-      Log::Info("Insert duplicated, workerId={}, key={}, treeId={}", cr::TxManager::My().worker_id_,
+      Log::Info("Insert duplicated, workerId={}, key={}, treeId={}", CoroEnv::CurTxMgr().worker_id_,
                 key.ToString(), tree_id_);
       JUMPMU_RETURN OpCode::kDuplicated;
     }
 
     if (ret != OpCode::kOK) {
-      Log::Info("Insert failed, workerId={}, key={}, ret={}", cr::TxManager::My().worker_id_,
+      Log::Info("Insert failed, workerId={}, key={}, ret={}", CoroEnv::CurTxMgr().worker_id_,
                 key.ToString(), ToString(ret));
       JUMPMU_RETURN ret;
     }

--- a/src/btree/core/b_tree_node.cpp
+++ b/src/btree/core/b_tree_node.cpp
@@ -25,7 +25,7 @@ void BTreeNode::UpdateHint(uint16_t slot_id) {
 
 void BTreeNode::SearchHint(HeadType key_head, uint16_t& lower_out, uint16_t& upper_out) {
   if (num_slots_ > kHintCount * 2) {
-    if (utils::tls_store->store_option_->btree_hints_ == 2) {
+    if (CoroEnv::CurStore()->store_option_->btree_hints_ == 2) {
 #ifdef __AVX512F__
       const uint16_t dist = num_slots_ / (kHintCount + 1);
       uint16_t pos, pos2;
@@ -48,7 +48,7 @@ void BTreeNode::SearchHint(HeadType key_head, uint16_t& lower_out, uint16_t& upp
 #else
       Log::Error("Search hint with AVX512 failed: __AVX512F__ not found");
 #endif
-    } else if (utils::tls_store->store_option_->btree_hints_ == 1) {
+    } else if (CoroEnv::CurStore()->store_option_->btree_hints_ == 1) {
       const uint16_t dist = num_slots_ / (kHintCount + 1);
       uint16_t pos, pos2;
 

--- a/src/concurrency/cr_manager.cpp
+++ b/src/concurrency/cr_manager.cpp
@@ -8,6 +8,7 @@
 #include "leanstore/concurrency/worker_thread.hpp"
 #include "leanstore/lean_store.hpp"
 #include "leanstore/utils/log.hpp"
+#include "utils/coroutine/coro_env.hpp"
 #include "utils/coroutine/mvcc_manager.hpp"
 #include "utils/json.hpp"
 
@@ -45,7 +46,7 @@ void CRManager::StartWorkerThreads(uint64_t num_worker_threads) {
     auto worker_thread = std::make_unique<WorkerThread>(store_, i, i);
     worker_thread->Start();
     auto* tx_mgr = tx_mgrs[i].get();
-    worker_thread->SetJob([tx_mgr]() { TxManager::s_tls_tx_manager = tx_mgr; });
+    worker_thread->SetJob([tx_mgr]() { CoroEnv::SetCurTxMgr(tx_mgr); });
     worker_thread->Wait();
     worker_threads_.emplace_back(std::move(worker_thread));
   }

--- a/src/concurrency/logging.cpp
+++ b/src/concurrency/logging.cpp
@@ -63,8 +63,8 @@ void Logging::WriteWalTxAbort() {
   wal_buffered_ += size;
   PublishWalFlushReq();
 
-  LEAN_DLOG("WriteWalTxAbort, workerId={}, startTs={}, walJson={}", TxManager::My().worker_id_,
-            TxManager::My().active_tx_.start_ts_, utils::ToJsonString(entry));
+  LEAN_DLOG("WriteWalTxAbort, workerId={}, startTs={}, walJson={}", CoroEnv::CurTxMgr().worker_id_,
+            CoroEnv::CurTxMgr().ActiveTx().start_ts_, utils::ToJsonString(entry));
 }
 
 void Logging::WriteWalTxFinish() {
@@ -75,14 +75,14 @@ void Logging::WriteWalTxFinish() {
   // Initialize a WalTxFinish
   auto* data = wal_buffer_ + wal_buffered_;
   std::memset(data, 0, size);
-  auto* entry [[maybe_unused]] = new (data) WalTxFinish(TxManager::My().active_tx_.start_ts_);
+  auto* entry [[maybe_unused]] = new (data) WalTxFinish(CoroEnv::CurTxMgr().ActiveTx().start_ts_);
 
   // Submit the WalTxAbort to group committer
   wal_buffered_ += size;
   PublishWalFlushReq();
 
-  LEAN_DLOG("WriteWalTxFinish, workerId={}, startTs={}, walJson={}", TxManager::My().worker_id_,
-            TxManager::My().active_tx_.start_ts_, utils::ToJsonString(entry));
+  LEAN_DLOG("WriteWalTxFinish, workerId={}, startTs={}, walJson={}", CoroEnv::CurTxMgr().worker_id_,
+            CoroEnv::CurTxMgr().ActiveTx().start_ts_, utils::ToJsonString(entry));
 }
 
 void Logging::WriteWalCarriageReturn() {
@@ -100,8 +100,9 @@ void Logging::SubmitWALEntryComplex(uint64_t total_size) {
   wal_buffered_ += total_size;
   PublishWalFlushReq();
 
-  LEAN_DLOG("SubmitWal, workerId={}, startTs={}, walJson={}", TxManager::My().worker_id_,
-            TxManager::My().active_tx_.start_ts_, utils::ToJsonString(active_walentry_complex_));
+  LEAN_DLOG("SubmitWal, workerId={}, startTs={}, walJson={}", CoroEnv::CurTxMgr().worker_id_,
+            CoroEnv::CurTxMgr().ActiveTx().start_ts_,
+            utils::ToJsonString(active_walentry_complex_));
 }
 
 void Logging::PublishWalBufferedOffset() {
@@ -109,7 +110,7 @@ void Logging::PublishWalBufferedOffset() {
 }
 
 void Logging::PublishWalFlushReq() {
-  WalFlushReq current(wal_buffered_, sys_tx_writtern_, TxManager::My().active_tx_.start_ts_);
+  WalFlushReq current(wal_buffered_, sys_tx_writtern_, CoroEnv::CurTxMgr().ActiveTx().start_ts_);
   wal_flush_req_.Set(current);
 }
 

--- a/src/concurrency/tx_manager.cpp
+++ b/src/concurrency/tx_manager.cpp
@@ -19,7 +19,6 @@
 
 namespace leanstore::cr {
 
-thread_local TxManager* TxManager::s_tls_tx_manager = nullptr;
 thread_local PerfCounters tls_perf_counters;
 
 TxManager::TxManager(uint64_t worker_id, std::vector<std::unique_ptr<TxManager>>& tx_mgrs,

--- a/src/leanstore-c/kv_txn.cpp
+++ b/src/leanstore-c/kv_txn.cpp
@@ -21,19 +21,19 @@
 
 void LsStartTx(LeanStoreHandle* handle, uint64_t worker_id) {
   auto* store = reinterpret_cast<leanstore::LeanStore*>(GetLeanStore(handle));
-  store->ExecSync(worker_id, [&]() { leanstore::cr::TxManager::My().StartTx(); });
+  store->ExecSync(worker_id, [&]() { leanstore::CoroEnv::CurTxMgr().StartTx(); });
 }
 
 /// Commit a transaction in a leanstore worker
 void LsCommitTx(LeanStoreHandle* handle, uint64_t worker_id) {
   auto* store = reinterpret_cast<leanstore::LeanStore*>(GetLeanStore(handle));
-  store->ExecSync(worker_id, [&]() { leanstore::cr::TxManager::My().CommitTx(); });
+  store->ExecSync(worker_id, [&]() { leanstore::CoroEnv::CurTxMgr().CommitTx(); });
 }
 
 /// Abort a transaction in a leanstore worker
 void LsAbortTx(LeanStoreHandle* handle, uint64_t worker_id) {
   auto* store = reinterpret_cast<leanstore::LeanStore*>(GetLeanStore(handle));
-  store->ExecSync(worker_id, [&]() { leanstore::cr::TxManager::My().AbortTx(); });
+  store->ExecSync(worker_id, [&]() { leanstore::CoroEnv::CurTxMgr().AbortTx(); });
 }
 
 //------------------------------------------------------------------------------

--- a/src/leanstore-c/store_option.cpp
+++ b/src/leanstore-c/store_option.cpp
@@ -13,6 +13,7 @@ static constexpr StoreOption kDefaultStoreOption = {
 
     // Worker thread related options
     .worker_threads_ = 4,
+    .max_concurrent_tx_per_worker_ = 1,
 
     // Buffer pool related options
     .page_size_ = 4 << 10,                // 4KB

--- a/src/utils/coroutine/auto_commit_protocol.cpp
+++ b/src/utils/coroutine/auto_commit_protocol.cpp
@@ -10,11 +10,11 @@
 namespace leanstore {
 
 bool AutoCommitProtocol::LogFlush() {
-  return cr::TxManager::My().GetLogging().CoroFlush();
+  return CoroEnv::CurTxMgr().GetLogging().CoroFlush();
 }
 
 void AutoCommitProtocol::CommitSysTx() {
-  auto& cur_worker_ctx = cr::TxManager::My();
+  auto& cur_worker_ctx = CoroEnv::CurTxMgr();
   auto sys_tx_written = cur_worker_ctx.GetLogging().GetSysTxWrittern();
   cur_worker_ctx.UpdateLastCommittedSysTx(sys_tx_written);
 }
@@ -33,32 +33,32 @@ void AutoCommitProtocol::CommitUsrTx() {
     signaled_up_to = std::min<TXID>(max_commit_ts, max_commit_ts_rfa);
   }
   if (signaled_up_to > 0) {
-    cr::TxManager::My().UpdateLastCommittedUsrTx(signaled_up_to);
+    CoroEnv::CurTxMgr().UpdateLastCommittedUsrTx(signaled_up_to);
   }
 }
 
 void AutoCommitProtocol::TrySyncLastCommittedTx() {
   ScopedTimer timer([&](double elapsed_ms) {
-    utils::tls_store->MvccManager()->UpdateMinCommittedSysTx(min_committed_sys_tx_);
+    CoroEnv::CurStore()->MvccManager()->UpdateMinCommittedSysTx(min_committed_sys_tx_);
     LEAN_DLOG("SyncLastCommittedTx finished, workerId={}, elapsed_ms={}"
               ", min_committed_sys_tx={}, min_committed_usr_tx={}",
-              cr::TxManager::My().worker_id_, elapsed_ms, min_committed_sys_tx_,
+              CoroEnv::CurTxMgr().worker_id_, elapsed_ms, min_committed_sys_tx_,
               min_committed_usr_tx_);
   });
 
-  auto& all_worker_ctxs = CoroEnv::AllWorkerCtxs();
-  for (auto i = 0u; i < all_worker_ctxs.size(); i++) {
-    auto& worker_ctx = all_worker_ctxs[i];
+  auto& tx_mgrs = store_->MvccManager()->TxMgrs();
+  for (auto i = 0u; i < tx_mgrs.size(); i++) {
+    auto& tx_mgr = tx_mgrs[i];
 
     // sync last committed sys tx
-    auto last_committed_sys_tx = worker_ctx->GetLastCommittedSysTx();
+    auto last_committed_sys_tx = tx_mgr->GetLastCommittedSysTx();
     if (last_committed_sys_tx != last_committed_sys_tx_[i]) {
       last_committed_sys_tx_[i] = last_committed_sys_tx;
       min_committed_sys_tx_ = std::min(min_committed_sys_tx_, last_committed_sys_tx);
     }
 
     // sync last committed user tx
-    auto last_committed_usr_tx = worker_ctx->GetLastCommittedUsrTx();
+    auto last_committed_usr_tx = tx_mgr->GetLastCommittedUsrTx();
     if (last_committed_usr_tx != last_committed_usr_tx_[i]) {
       last_committed_usr_tx_[i] = last_committed_usr_tx;
       min_committed_usr_tx_ = std::min(min_committed_usr_tx_, last_committed_usr_tx);
@@ -68,7 +68,7 @@ void AutoCommitProtocol::TrySyncLastCommittedTx() {
 
 TXID AutoCommitProtocol::DetermineCommitableUsrTx() {
   TXID max_commit_ts = 0;
-  auto& logging = cr::TxManager::My().GetLogging();
+  auto& logging = CoroEnv::CurTxMgr().GetLogging();
   auto& tx_queue = logging.tx_to_commit_;
 
   auto i = 0u;
@@ -90,11 +90,11 @@ TXID AutoCommitProtocol::DetermineCommitableUsrTx() {
 
 TXID AutoCommitProtocol::DetermineCommitableUsrTxRfA() {
   TXID max_commit_ts = 0;
-  for (auto& tx : cr::TxManager::My().GetLogging().rfa_tx_to_commit_) {
+  for (auto& tx : CoroEnv::CurTxMgr().GetLogging().rfa_tx_to_commit_) {
     max_commit_ts = std::max<TXID>(max_commit_ts, tx.commit_ts_);
     LEAN_DLOG("RFA Transaction committed, startTs={}, commitTs={}", tx.start_ts_, tx.commit_ts_);
   }
-  cr::TxManager::My().GetLogging().rfa_tx_to_commit_.clear();
+  CoroEnv::CurTxMgr().GetLogging().rfa_tx_to_commit_.clear();
   return max_commit_ts;
 }
 

--- a/src/utils/coroutine/auto_commit_protocol.hpp
+++ b/src/utils/coroutine/auto_commit_protocol.hpp
@@ -6,9 +6,13 @@
 
 namespace leanstore {
 
+class LeanStore;
+
 class AutoCommitProtocol {
 public:
-  AutoCommitProtocol(uint32_t commit_group, uint64_t num_workers) : group_id_(commit_group) {
+  AutoCommitProtocol(LeanStore* store, uint32_t commit_group, uint64_t num_workers)
+      : store_(store),
+        group_id_(commit_group) {
     last_committed_sys_tx_.resize(num_workers, 0);
     last_committed_usr_tx_.resize(num_workers, 0);
   };
@@ -56,6 +60,8 @@ private:
   TXID DetermineCommitableUsrTxRfA();
 
 private:
+  LeanStore* store_;
+
   /// Commit group id, identifies the group of workers that are committing
   /// together.  All workers in the same commit group shares the same
   /// AutoCommitProtocol instance and the same commit acknowledgment.

--- a/src/utils/coroutine/coro_env.hpp
+++ b/src/utils/coroutine/coro_env.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
-#include <vector>
 
 namespace leanstore::cr {
 class Logging;
 class TxManager;
+class Transaction;
 } // namespace leanstore::cr
 
 namespace leanstore {
 
+class LeanStore;
 class Coroutine;
 class CoroExecutor;
 
@@ -19,9 +19,15 @@ public:
   static constexpr int64_t kMaxCoroutinesPerThread = 256;
   static constexpr int64_t kStackSize = 8 << 20; // 8 MB
 
-  static Coroutine* CurCoro();
+  static void SetCurStore(LeanStore* store);
+  static LeanStore* CurStore();
+
   static CoroExecutor* CurCoroExec();
-  static std::vector<std::unique_ptr<cr::TxManager>>& AllWorkerCtxs();
+  static Coroutine* CurCoro();
+
+  static void SetCurTxMgr(cr::TxManager* tx_mgr);
+  static cr::TxManager& CurTxMgr();
+  static bool HasTxMgr();
 };
 
 } // namespace leanstore

--- a/src/utils/coroutine/coro_executor.hpp
+++ b/src/utils/coroutine/coro_executor.hpp
@@ -127,7 +127,7 @@ private:
     pthread_setname_np(pthread_self(), thread_name.c_str());
     s_current_thread = this;
     JumpContext::SetCurrent(&def_jump_context_);
-    utils::tls_store = store_;
+    CoroEnv::SetCurStore(store_);
 
     ready_ = true;
     Log::Info("Coro executor inited, thread_name={}", thread_name);

--- a/src/utils/coroutine/coroutine.hpp
+++ b/src/utils/coroutine/coroutine.hpp
@@ -83,6 +83,14 @@ public:
     return state_;
   }
 
+  void SetTxMgr(cr::TxManager* tx_mgr) {
+    tx_mgr_ = tx_mgr;
+  }
+
+  cr::TxManager* GetTxMgr() const {
+    return tx_mgr_;
+  }
+
   void SetTryLockFunc(std::function<bool()> try_lock_func) {
     try_lock_func_ = std::move(try_lock_func);
   }
@@ -140,6 +148,9 @@ private:
   /// Function to be executed by the coroutine.
   /// This is a callable object that contains the logic of the coroutine.
   CoroFunc func_ = nullptr;
+
+  /// Pointer to the transaction manager associated with this coroutine.
+  cr::TxManager* tx_mgr_ = nullptr;
 
   /// Try lock function for the coroutine.
   std::function<bool()> try_lock_func_ = nullptr;

--- a/src/utils/small_vector.hpp
+++ b/src/utils/small_vector.hpp
@@ -96,6 +96,8 @@ private:
 template <size_t stack_limit>
 using SmallBuffer = SmallVector<uint8_t, stack_limit>;
 
+using SmallBuffer256 = SmallBuffer<256>;
+
 template <size_t stack_limit>
 using SmallBuffer512Aligned = SmallVectorAligned<uint8_t, stack_limit, 512>;
 

--- a/tests/btree/b_tree_generic_test.cpp
+++ b/tests/btree/b_tree_generic_test.cpp
@@ -49,8 +49,8 @@ protected:
 
   void TearDown() override {
     store_->ExecSync(1, [&]() {
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
       store_->DropTransactionKV(tree_name_);
     });
   }
@@ -63,8 +63,8 @@ TEST_F(BTreeGenericTest, GetSummary) {
       auto key = RandomGenerator::RandAlphString(24) + std::to_string(i);
       auto val = RandomGenerator::RandAlphString(176);
 
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
       btree_->Insert(key, val);
     });
   }

--- a/tests/coroutine/coro_transaction_test.cpp
+++ b/tests/coroutine/coro_transaction_test.cpp
@@ -71,9 +71,9 @@ TEST_F(CoroTxnTest, BasicCommit) {
   // insert key-value pairs in worker 0
   auto job_insert = [&]() {
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(key, val), OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
   };
   store->Submit(job_insert, 0)->Wait();

--- a/tests/mvcc_test.cpp
+++ b/tests/mvcc_test.cpp
@@ -51,8 +51,8 @@ protected:
 
   void TearDown() override {
     store_->ExecSync(1, [&]() {
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
       store_->DropTransactionKV(tree_name_);
     });
   }
@@ -63,10 +63,10 @@ TEST_F(MvccTest, LookupWhileInsert) {
   auto key0 = RandomGenerator::RandAlphString(42);
   auto val0 = RandomGenerator::RandAlphString(151);
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     auto res = btree_->Insert(Slice((const uint8_t*)key0.data(), key0.size()),
                               Slice((const uint8_t*)val0.data(), val0.size()));
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
     EXPECT_EQ(res, OpCode::kOK);
   });
 
@@ -74,7 +74,7 @@ TEST_F(MvccTest, LookupWhileInsert) {
   auto key1 = RandomGenerator::RandAlphString(17);
   auto val1 = RandomGenerator::RandAlphString(131);
   store_->ExecSync(1, [&]() {
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     auto res = btree_->Insert(Slice((const uint8_t*)key1.data(), key1.size()),
                               Slice((const uint8_t*)val1.data(), val1.size()));
     EXPECT_EQ(res, OpCode::kOK);
@@ -87,11 +87,11 @@ TEST_F(MvccTest, LookupWhileInsert) {
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
     };
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(btree_->Lookup(Slice((const uint8_t*)key0.data(), key0.size()), copy_value_out),
               OpCode::kOK);
     EXPECT_EQ(copied_value, val0);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 
   // commit the transaction
@@ -104,7 +104,7 @@ TEST_F(MvccTest, LookupWhileInsert) {
     EXPECT_EQ(btree_->Lookup(Slice((const uint8_t*)key1.data(), key1.size()), copy_value_out),
               OpCode::kOK);
     EXPECT_EQ(copied_value, val1);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 
   // now we can see the latest record
@@ -113,11 +113,11 @@ TEST_F(MvccTest, LookupWhileInsert) {
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
     };
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(btree_->Lookup(Slice((const uint8_t*)key1.data(), key1.size()), copy_value_out),
               OpCode::kOK);
     EXPECT_EQ(copied_value, val1);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -126,10 +126,10 @@ TEST_F(MvccTest, InsertConflict) {
   auto key0 = RandomGenerator::RandAlphString(42);
   auto val0 = RandomGenerator::RandAlphString(151);
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     auto res = btree_->Insert(Slice((const uint8_t*)key0.data(), key0.size()),
                               Slice((const uint8_t*)val0.data(), val0.size()));
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
     EXPECT_EQ(res, OpCode::kOK);
   });
 
@@ -137,7 +137,7 @@ TEST_F(MvccTest, InsertConflict) {
   auto key1 = key0 + "a";
   auto val1 = val0;
   store_->ExecSync(1, [&]() {
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     auto res = btree_->Insert(Slice((const uint8_t*)key1.data(), key1.size()),
                               Slice((const uint8_t*)val1.data(), val1.size()));
     EXPECT_EQ(res, OpCode::kOK);
@@ -145,22 +145,22 @@ TEST_F(MvccTest, InsertConflict) {
 
   // start another transaction to insert the same key
   store_->ExecSync(2, [&]() {
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     auto res = btree_->Insert(Slice((const uint8_t*)key1.data(), key1.size()),
                               Slice((const uint8_t*)val1.data(), val1.size()));
     EXPECT_EQ(res, OpCode::kAbortTx);
-    cr::TxManager::My().AbortTx();
+    CoroEnv::CurTxMgr().AbortTx();
   });
 
   // start another transaction to insert a smaller key
   auto key2 = std::string(key0.data(), key0.size() - 1);
   auto val2 = val0;
   store_->ExecSync(2, [&]() {
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     auto res = btree_->Insert(Slice((const uint8_t*)key1.data(), key1.size()),
                               Slice((const uint8_t*)val1.data(), val1.size()));
     EXPECT_EQ(res, OpCode::kAbortTx);
-    cr::TxManager::My().AbortTx();
+    CoroEnv::CurTxMgr().AbortTx();
   });
 
   // commit the transaction
@@ -173,7 +173,7 @@ TEST_F(MvccTest, InsertConflict) {
     EXPECT_EQ(btree_->Lookup(Slice((const uint8_t*)key1.data(), key1.size()), copy_value_out),
               OpCode::kOK);
     EXPECT_EQ(copied_value, val1);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 
   // now we can see the latest record
@@ -182,11 +182,11 @@ TEST_F(MvccTest, InsertConflict) {
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
     };
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(btree_->Lookup(Slice((const uint8_t*)key1.data(), key1.size()), copy_value_out),
               OpCode::kOK);
     EXPECT_EQ(copied_value, val1);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 

--- a/tests/recovery_test.cpp
+++ b/tests/recovery_test.cpp
@@ -68,8 +68,8 @@ TEST_F(RecoveryTest, SerializeAndDeserialize) {
 
   // insert some values
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
       EXPECT_EQ(btree->Insert(key, val), OpCode::kOK);
@@ -98,8 +98,8 @@ TEST_F(RecoveryTest, SerializeAndDeserialize) {
 
   // lookup the restored btree
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     std::string copied_value;
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
@@ -113,8 +113,8 @@ TEST_F(RecoveryTest, SerializeAndDeserialize) {
   });
 
   store_->ExecSync(1, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     store_->DropTransactionKV(btree_name);
   });
 
@@ -146,12 +146,12 @@ TEST_F(RecoveryTest, RecoverAfterInsert) {
     EXPECT_NE(btree, nullptr);
 
     // insert some values
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
       EXPECT_EQ(btree->Insert(key, val), OpCode::kOK);
     }
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 
   // skip dumpping buffer frames on exit
@@ -172,8 +172,8 @@ TEST_F(RecoveryTest, RecoverAfterInsert) {
 
   // lookup the restored btree
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     std::string copied_value;
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
@@ -233,9 +233,9 @@ TEST_F(RecoveryTest, RecoverAfterUpdate) {
     // insert some values
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(key, val), OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     // update all the values
@@ -247,9 +247,9 @@ TEST_F(RecoveryTest, RecoverAfterUpdate) {
       // update each key 3 times
       for (auto j = 1u; j <= 3; j++) {
         val = GenerateValue(j, val_size);
-        cr::TxManager::My().StartTx();
+        CoroEnv::CurTxMgr().StartTx();
         EXPECT_EQ(btree->UpdatePartial(key, update_call_back, *update_desc), OpCode::kOK);
-        cr::TxManager::My().CommitTx();
+        CoroEnv::CurTxMgr().CommitTx();
       }
     }
   });
@@ -272,8 +272,8 @@ TEST_F(RecoveryTest, RecoverAfterUpdate) {
 
   // lookup the restored btree
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     std::string copied_value;
     auto copy_value_out = [&](Slice val) { copied_value = val.ToString(); };
     for (size_t i = 0; i < num_keys; ++i) {
@@ -312,17 +312,17 @@ TEST_F(RecoveryTest, RecoverAfterRemove) {
     // insert some values
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(key, val), OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     // remove all the values
     for (size_t i = 0; i < num_keys; ++i) {
       auto& [key, val] = kv_to_test[i];
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Remove(key), OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
   });
 
@@ -344,8 +344,8 @@ TEST_F(RecoveryTest, RecoverAfterRemove) {
 
   // lookup the restored btree
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     std::string copied_value;
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());

--- a/tests/transaction_kv_test.cpp
+++ b/tests/transaction_kv_test.cpp
@@ -73,8 +73,8 @@ TEST_F(TransactionKVTest, Create) {
   });
 
   store_->ExecSync(1, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     store_->DropTransactionKV(btree_name);
     store_->DropTransactionKV(btree_name2);
   });
@@ -100,20 +100,20 @@ TEST_F(TransactionKVTest, InsertAndLookup) {
     EXPECT_NE(btree, nullptr);
 
     // insert some values
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
       EXPECT_EQ(btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                               Slice((const uint8_t*)val.data(), val.size())),
                 OpCode::kOK);
     }
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 
   // query on the created btree in the same worker
   store_->ExecSync(0, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     std::string copied_value;
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
@@ -128,8 +128,8 @@ TEST_F(TransactionKVTest, InsertAndLookup) {
 
   // query on the created btree in another worker
   store_->ExecSync(1, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     std::string copied_value;
     auto copy_value_out = [&](Slice val) {
       copied_value = std::string((const char*)val.data(), val.size());
@@ -143,8 +143,8 @@ TEST_F(TransactionKVTest, InsertAndLookup) {
   });
 
   store_->ExecSync(1, [&]() {
-    cr::TxManager::My().StartTx();
-    SCOPED_DEFER(cr::TxManager::My().CommitTx());
+    CoroEnv::CurTxMgr().StartTx();
+    SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
     store_->DropTransactionKV(btree_name);
   });
 }
@@ -163,7 +163,7 @@ TEST_F(TransactionKVTest, Insert1000KVs) {
     // insert numKVs tuples
     std::set<std::string> unique_keys;
     ssize_t num_keys(1000);
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     for (ssize_t i = 0; i < num_keys; ++i) {
       auto key = RandomGenerator::RandAlphString(24);
       if (unique_keys.find(key) != unique_keys.end()) {
@@ -176,11 +176,11 @@ TEST_F(TransactionKVTest, Insert1000KVs) {
                               Slice((const uint8_t*)val.data(), val.size())),
                 OpCode::kOK);
     }
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
 
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -206,24 +206,24 @@ TEST_F(TransactionKVTest, InsertDuplicates) {
       }
       unique_keys.insert(key);
       auto val = RandomGenerator::RandAlphString(128);
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                               Slice((const uint8_t*)val.data(), val.size())),
                 OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     // insert duplicated keys
     for (auto& key : unique_keys) {
       auto val = RandomGenerator::RandAlphString(128);
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(ToSlice(key), ToSlice(val)), OpCode::kDuplicated);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -250,29 +250,29 @@ TEST_F(TransactionKVTest, Remove) {
       unique_keys.insert(key);
       auto val = RandomGenerator::RandAlphString(128);
 
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                               Slice((const uint8_t*)val.data(), val.size())),
                 OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     for (auto& key : unique_keys) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Remove(Slice((const uint8_t*)key.data(), key.size())), OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     for (auto& key : unique_keys) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Lookup(Slice((const uint8_t*)key.data(), key.size()), [](Slice) {}),
                 OpCode::kNotFound);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -299,11 +299,11 @@ TEST_F(TransactionKVTest, RemoveNotExisted) {
       unique_keys.insert(key);
       auto val = RandomGenerator::RandAlphString(128);
 
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                               Slice((const uint8_t*)val.data(), val.size())),
                 OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     // remove keys not existed
@@ -315,14 +315,14 @@ TEST_F(TransactionKVTest, RemoveNotExisted) {
       }
       unique_keys.insert(key);
 
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Remove(Slice((const uint8_t*)key.data(), key.size())), OpCode::kNotFound);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -349,46 +349,46 @@ TEST_F(TransactionKVTest, RemoveFromOthers) {
       unique_keys.insert(key);
       auto val = RandomGenerator::RandAlphString(128);
 
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                               Slice((const uint8_t*)val.data(), val.size())),
                 OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
   });
 
   store_->ExecSync(1, [&]() {
     // remove from another worker
     for (auto& key : unique_keys) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Remove(Slice((const uint8_t*)key.data(), key.size())), OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
 
     // should not found any keys
     for (auto& key : unique_keys) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Lookup(Slice((const uint8_t*)key.data(), key.size()), [](Slice) {}),
                 OpCode::kNotFound);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
   });
 
   store_->ExecSync(0, [&]() {
     // lookup from another worker, should not found any keys
     for (auto& key : unique_keys) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Lookup(Slice((const uint8_t*)key.data(), key.size()), [](Slice) {}),
                 OpCode::kNotFound);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
   });
 
   store_->ExecSync(1, [&]() {
     // unregister the tree from another worker
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -416,10 +416,10 @@ TEST_F(TransactionKVTest, Update) {
     // insert values
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       auto res = btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                                Slice((const uint8_t*)val.data(), val.size()));
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(res, OpCode::kOK);
     }
 
@@ -438,10 +438,10 @@ TEST_F(TransactionKVTest, Update) {
     update_desc->update_slots_[0].size_ = val_size;
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       auto res = btree->UpdatePartial(Slice((const uint8_t*)key.data(), key.size()),
                                       update_call_back, *update_desc);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(res, OpCode::kOK);
     }
 
@@ -452,16 +452,16 @@ TEST_F(TransactionKVTest, Update) {
     };
     for (size_t i = 0; i < num_keys; ++i) {
       const auto& [key, val] = kv_to_test[i];
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       EXPECT_EQ(btree->Lookup(Slice((const uint8_t*)key.data(), key.size()), copy_value_out),
                 OpCode::kOK);
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(copied_value, new_val);
     }
 
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -500,10 +500,10 @@ TEST_F(TransactionKVTest, ScanAsc) {
 
     // insert values
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       auto res = btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                                Slice((const uint8_t*)val.data(), val.size()));
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(res, OpCode::kOK);
     }
 
@@ -517,11 +517,11 @@ TEST_F(TransactionKVTest, ScanAsc) {
 
     // scan from the smallest key
     copied_k_vs.clear();
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(
         btree->ScanAsc(Slice((const uint8_t*)smallest.data(), smallest.size()), scan_call_back),
         OpCode::kOK);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
     EXPECT_EQ(copied_k_vs.size(), num_keys);
     for (const auto& [key, val] : copied_k_vs) {
       EXPECT_EQ(val, kv_to_test[key]);
@@ -529,17 +529,17 @@ TEST_F(TransactionKVTest, ScanAsc) {
 
     // scan from the bigest key
     copied_k_vs.clear();
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(btree->ScanAsc(Slice((const uint8_t*)bigest.data(), bigest.size()), scan_call_back),
               OpCode::kOK);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
     EXPECT_EQ(copied_k_vs.size(), 1u);
     EXPECT_EQ(copied_k_vs[bigest], kv_to_test[bigest]);
 
     // destroy the tree
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -578,10 +578,10 @@ TEST_F(TransactionKVTest, ScanDesc) {
 
     // insert values
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       auto res = btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                                Slice((const uint8_t*)val.data(), val.size()));
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(res, OpCode::kOK);
     }
 
@@ -595,10 +595,10 @@ TEST_F(TransactionKVTest, ScanDesc) {
 
     // scan from the bigest key
     copied_k_vs.clear();
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(btree->ScanDesc(Slice((const uint8_t*)bigest.data(), bigest.size()), scan_call_back),
               OpCode::kOK);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
     EXPECT_EQ(copied_k_vs.size(), num_keys);
     for (const auto& [key, val] : copied_k_vs) {
       EXPECT_EQ(val, kv_to_test[key]);
@@ -606,18 +606,18 @@ TEST_F(TransactionKVTest, ScanDesc) {
 
     // scan from the smallest key
     copied_k_vs.clear();
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     EXPECT_EQ(
         btree->ScanDesc(Slice((const uint8_t*)smallest.data(), smallest.size()), scan_call_back),
         OpCode::kOK);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
     EXPECT_EQ(copied_k_vs.size(), 1u);
     EXPECT_EQ(copied_k_vs[smallest], kv_to_test[smallest]);
 
     // destroy the tree
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     store_->DropTransactionKV(btree_name);
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -661,18 +661,18 @@ TEST_F(TransactionKVTest, InsertAfterRemove) {
 
     // insert values
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       auto res = btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                                Slice((const uint8_t*)val.data(), val.size()));
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(res, OpCode::kOK);
     }
 
     // remove, insert, and lookup
     for (const auto& [key, val] : kv_to_test) {
       // remove
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
 
       EXPECT_EQ(btree->Remove(Slice((const uint8_t*)key.data(), key.size())), OpCode::kOK);
 
@@ -713,13 +713,13 @@ TEST_F(TransactionKVTest, InsertAfterRemove) {
             kv_to_test.begin()->first, kv_to_test.begin()->second, new_val);
   store_->ExecSync(1, [&]() {
     // lookup the new value
-    cr::TxManager::My().StartTx();
+    CoroEnv::CurTxMgr().StartTx();
     for (const auto& [key, val] : kv_to_test) {
       EXPECT_EQ(btree->Lookup(Slice((const uint8_t*)key.data(), key.size()), copy_value_out),
                 OpCode::kOK);
       EXPECT_EQ(copied_value, new_val);
     }
-    cr::TxManager::My().CommitTx();
+    CoroEnv::CurTxMgr().CommitTx();
   });
 }
 
@@ -763,25 +763,25 @@ TEST_F(TransactionKVTest, InsertAfterRemoveDifferentWorkers) {
 
     // insert values
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
+      CoroEnv::CurTxMgr().StartTx();
       auto res = btree->Insert(Slice((const uint8_t*)key.data(), key.size()),
                                Slice((const uint8_t*)val.data(), val.size()));
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
       EXPECT_EQ(res, OpCode::kOK);
     }
 
     // remove
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
       EXPECT_EQ(btree->Remove(Slice((const uint8_t*)key.data(), key.size())), OpCode::kOK);
     }
   });
 
   store_->ExecSync(1, [&]() {
     for (const auto& [key, val] : kv_to_test) {
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
 
       // remove twice should got not found error
       EXPECT_EQ(btree->Remove(Slice((const uint8_t*)key.data(), key.size())), OpCode::kNotFound);
@@ -834,8 +834,8 @@ TEST_F(TransactionKVTest, ConcurrentInsertWithSplit) {
   // insert in worker 0 asynchorously
   store_->ExecAsync(0, [&]() {
     for (auto i = 0; !stop; i++) {
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
       auto key = std::format("{}_{}_{}", RandomGenerator::RandAlphString(key_size), 0, i);
       auto val = RandomGenerator::RandAlphString(val_size);
       auto res = btree->Insert(key, val);
@@ -846,8 +846,8 @@ TEST_F(TransactionKVTest, ConcurrentInsertWithSplit) {
   // insert in worker 1 asynchorously
   store_->ExecAsync(1, [&]() {
     for (auto i = 0; !stop; i++) {
-      cr::TxManager::My().StartTx();
-      SCOPED_DEFER(cr::TxManager::My().CommitTx());
+      CoroEnv::CurTxMgr().StartTx();
+      SCOPED_DEFER(CoroEnv::CurTxMgr().CommitTx());
       auto key = std::format("{}_{}_{}", RandomGenerator::RandAlphString(key_size), 1, i);
       auto val = RandomGenerator::RandAlphString(val_size);
       auto res = btree->Insert(key, val);

--- a/tests/tx_kv.hpp
+++ b/tests/tx_kv.hpp
@@ -184,15 +184,15 @@ inline void LeanStoreMVCCSession::SetTxMode(TxMode tx_mode) {
 
 inline void LeanStoreMVCCSession::StartTx() {
   store_->lean_store_->ExecSync(worker_id_,
-                                [&]() { cr::TxManager::My().StartTx(tx_mode_, isolation_level_); });
+                                [&]() { CoroEnv::CurTxMgr().StartTx(tx_mode_, isolation_level_); });
 }
 
 inline void LeanStoreMVCCSession::CommitTx() {
-  store_->lean_store_->ExecSync(worker_id_, [&]() { cr::TxManager::My().CommitTx(); });
+  store_->lean_store_->ExecSync(worker_id_, [&]() { CoroEnv::CurTxMgr().CommitTx(); });
 }
 
 inline void LeanStoreMVCCSession::AbortTx() {
-  store_->lean_store_->ExecSync(worker_id_, [&]() { cr::TxManager::My().AbortTx(); });
+  store_->lean_store_->ExecSync(worker_id_, [&]() { CoroEnv::CurTxMgr().AbortTx(); });
 }
 
 // DDL operations
@@ -214,11 +214,11 @@ inline Result<TableRef*> LeanStoreMVCCSession::CreateTable(const std::string& tb
 inline Result<void> LeanStoreMVCCSession::DropTable(const std::string& tbl_name, bool implicit_tx) {
   store_->lean_store_->ExecSync(worker_id_, [&]() {
     if (implicit_tx) {
-      cr::TxManager::My().StartTx(tx_mode_, isolation_level_);
+      CoroEnv::CurTxMgr().StartTx(tx_mode_, isolation_level_);
     }
     store_->lean_store_->DropTransactionKV(tbl_name);
     if (implicit_tx) {
-      cr::TxManager::My().CommitTx();
+      CoroEnv::CurTxMgr().CommitTx();
     }
   });
   return {};
@@ -231,13 +231,13 @@ inline Result<void> LeanStoreMVCCSession::Put(TableRef* tbl, Slice key, Slice va
   OpCode res;
   store_->lean_store_->ExecSync(worker_id_, [&]() {
     if (implicit_tx) {
-      cr::TxManager::My().StartTx(tx_mode_, isolation_level_);
+      CoroEnv::CurTxMgr().StartTx(tx_mode_, isolation_level_);
     }
     SCOPED_DEFER(if (implicit_tx) {
       if (res == OpCode::kOK) {
-        cr::TxManager::My().CommitTx();
+        CoroEnv::CurTxMgr().CommitTx();
       } else {
-        cr::TxManager::My().AbortTx();
+        CoroEnv::CurTxMgr().AbortTx();
       }
     });
 
@@ -261,13 +261,13 @@ inline Result<uint64_t> LeanStoreMVCCSession::Get(TableRef* tbl, Slice key, std:
 
   store_->lean_store_->ExecSync(worker_id_, [&]() {
     if (implicit_tx) {
-      cr::TxManager::My().StartTx(tx_mode_, isolation_level_);
+      CoroEnv::CurTxMgr().StartTx(tx_mode_, isolation_level_);
     }
     SCOPED_DEFER(if (implicit_tx) {
       if (res == OpCode::kOK || res == OpCode::kNotFound) {
-        cr::TxManager::My().CommitTx();
+        CoroEnv::CurTxMgr().CommitTx();
       } else {
-        cr::TxManager::My().AbortTx();
+        CoroEnv::CurTxMgr().AbortTx();
       }
     });
 
@@ -291,13 +291,13 @@ inline Result<uint64_t> LeanStoreMVCCSession::Update(TableRef* tbl, Slice key, S
   };
   store_->lean_store_->ExecSync(worker_id_, [&]() {
     if (implicit_tx) {
-      cr::TxManager::My().StartTx(tx_mode_, isolation_level_);
+      CoroEnv::CurTxMgr().StartTx(tx_mode_, isolation_level_);
     }
     SCOPED_DEFER(if (implicit_tx) {
       if (res == OpCode::kOK || res == OpCode::kNotFound) {
-        cr::TxManager::My().CommitTx();
+        CoroEnv::CurTxMgr().CommitTx();
       } else {
-        cr::TxManager::My().AbortTx();
+        CoroEnv::CurTxMgr().AbortTx();
       }
     });
 
@@ -324,13 +324,13 @@ inline Result<uint64_t> LeanStoreMVCCSession::Delete(TableRef* tbl, Slice key, b
   OpCode res;
   store_->lean_store_->ExecSync(worker_id_, [&]() {
     if (implicit_tx) {
-      cr::TxManager::My().StartTx(tx_mode_, isolation_level_);
+      CoroEnv::CurTxMgr().StartTx(tx_mode_, isolation_level_);
     }
     SCOPED_DEFER(if (implicit_tx) {
       if (res == OpCode::kOK || res == OpCode::kNotFound) {
-        cr::TxManager::My().CommitTx();
+        CoroEnv::CurTxMgr().CommitTx();
       } else {
-        cr::TxManager::My().AbortTx();
+        CoroEnv::CurTxMgr().AbortTx();
       }
     });
 


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

This pull request refactors the codebase to replace direct usage of thread-local transaction and store managers (`cr::TxManager::My()` and `utils::tls_store`) with coroutine-aware environment accessors (`CoroEnv::CurTxMgr()` and `CoroEnv::CurStore()`). This change improves compatibility with coroutine-based concurrency and makes transaction and store context management more robust and explicit. Additionally, a new store option for maximum concurrent transactions per worker is introduced.

**Coroutine-aware transaction and store manager refactoring:**

* Replaced all instances of `cr::TxManager::My()` and `utils::tls_store` with `CoroEnv::CurTxMgr()` and `CoroEnv::CurStore()` throughout the codebase, including transaction handling, buffer management, B-tree operations, and logging. This affects files such as `insert_update_bench.cpp`, `ycsb_leanstore.hpp`, `chained_tuple.hpp`, `b_tree_node.hpp`, `btree_iter_mut.hpp`, `btree_iter_pessistic.hpp`, `transaction_kv.hpp`, `buffer_frame.hpp`, `guarded_buffer_frame.hpp`, `logging_impl.hpp`, `transaction.hpp`, `wal_payload_handler.hpp`, and `managed_thread.hpp`. [[1]](diffhunk://#diff-2b7d76b3d23a3365b37df41196e575ba5af93cb4f1a1d590643c768114b54432L42-R43) [[2]](diffhunk://#diff-1ee0276e80b0e7fc8d2c8332a32c4a7eae62a844cd5743af3bde5f77a84bc346L165-R165) [[3]](diffhunk://#diff-d3970fae410cad93820b96585f53f197ec5409f3fbc33792b3340692e977cd44L66-R70) [[4]](diffhunk://#diff-9d208df9684577bd46cedba8974c706b4c0262ebc9479cf34f9af0f050edbb9fL474-R474) [[5]](diffhunk://#diff-8413fd77eb7375321b0adaf828726d8a124ce6a43a71a9d56d8532bd46c27b88L138-R146) [[6]](diffhunk://#diff-55d14df61ab1cc09e8bfb87019245af2a8fb2ec7bb9fcef34bad4a8dd5b4d891L340-R340) [[7]](diffhunk://#diff-96a5000c908f7d029cba8df446f13941ed802a3e0e76d3a63a403933ee5c6bfeL114-R114) [[8]](diffhunk://#diff-2f030467ba3cab38007b4325bb31c74ca5210304b042a934ce8616206eb53d39L155-R155) [[9]](diffhunk://#diff-34f08e343af62b110f783f4478513abcb4ec29609b486646aaf85e09dbd19829L156-R162) [[10]](diffhunk://#diff-1d455023a66860a58a78d24e3f7992f5a1392db5e586dc38477c17a34f582ba6L15-R18) [[11]](diffhunk://#diff-d826e0b06245f76adeba013f7e09de4ffc03ee55b434497f764e818908b9a746L91-R91) [[12]](diffhunk://#diff-efb6d9490d8abc564dd47e1fb61fe3a8489e1e58041ffb783062ff58e558ed3bL40-R40) [[13]](diffhunk://#diff-76787fb71187527ac68aeb419690eb3d2b182b422d93cb21d0456f6a95bd49adL77-R77)

**API and shortcut cleanup:**

* Removed the `TxManager::My()` shortcut and related global transaction accessors from `tx_manager.hpp` to enforce explicit context passing and discourage global state usage.
* Added a new `ActiveTx()` member function to `TxManager` for accessing the current transaction.

**Configuration improvements:**

* Added a new configuration option `max_concurrent_tx_per_worker_` to the `StoreOption` struct in `store_option.h`, allowing users to specify the maximum number of concurrent transactions per worker thread.

**Thread-local store management changes:**

* Removed the global `tls_store` thread-local variable and replaced its usage with `CoroEnv::SetCurStore()` for setting the current store context in `ManagedThread`. [[1]](diffhunk://#diff-76787fb71187527ac68aeb419690eb3d2b182b422d93cb21d0456f6a95bd49adL22) [[2]](diffhunk://#diff-76787fb71187527ac68aeb419690eb3d2b182b422d93cb21d0456f6a95bd49adL77-R77)

**Include and dependency updates:**

* Updated includes to reference `coro_env.hpp` where necessary to support the new coroutine environment accessors. [[1]](diffhunk://#diff-2b7d76b3d23a3365b37df41196e575ba5af93cb4f1a1d590643c768114b54432R8) [[2]](diffhunk://#diff-d3970fae410cad93820b96585f53f197ec5409f3fbc33792b3340692e977cd44R10) [[3]](diffhunk://#diff-76787fb71187527ac68aeb419690eb3d2b182b422d93cb21d0456f6a95bd49adR6)