### PR TITLE
chore: use array to manage running coroutines

### DIFF
--- a/include/leanstore-c/store_option.h
+++ b/include/leanstore-c/store_option.h
@@ -45,6 +45,9 @@ typedef struct StoreOption {
   /// Maximum number of concurrent transactions per worker thread.
   uint64_t max_concurrent_tx_per_worker_;
 
+  /// Maximum number of concurrent coroutines per worker thread.
+  uint64_t coro_slots_per_worker_;
+
   // ---------------------------------------------------------------------------
   // Buffer pool related options
   // ---------------------------------------------------------------------------

--- a/src/leanstore-c/store_option.cpp
+++ b/src/leanstore-c/store_option.cpp
@@ -14,6 +14,7 @@ static constexpr StoreOption kDefaultStoreOption = {
     // Worker thread related options
     .worker_threads_ = 4,
     .max_concurrent_tx_per_worker_ = 1,
+    .coro_slots_per_worker_ = 8,
 
     // Buffer pool related options
     .page_size_ = 4 << 10,                // 4KB

--- a/src/utils/coroutine/blocking_queue_mpsc.hpp
+++ b/src/utils/coroutine/blocking_queue_mpsc.hpp
@@ -50,6 +50,20 @@ public:
     return true;
   }
 
+  bool TryPopFront(T& value) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (size_ == 0) {
+      return false;
+    }
+    value = std::move(queue_[head_]);
+    head_ = (head_ + 1) % capacity_;
+    size_--;
+
+    lock.unlock();
+    not_full_.notify_one();
+    return true;
+  }
+
   void Shutdown() {
     std::unique_lock<std::mutex> lock(mutex_);
     stopped_ = true;


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

Add an array to manage running user coroutines. 
- For every round, loop through the array and check if the slot if ready to run, or if the slot is empty, a new task will be pulled from task queue.
- If there is no ready coroutines and no new tasks, worker thread will wait until there is a new task or timeouts; the timeout can be removed if in the future when a yield task becomes ready can be notified to the worker thread.