### PR TITLE
chore: add code coverage for coroutine mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,18 @@ jobs:
     - name: Unit test with coroutine enabled
       run: ctest --test-dir build/debug_coro --output-on-failure -j 2
 
+    - name: Generate coverage file
+      run: gcovr -v -r . --xml-pretty --xml=coverage_coro.xml --exclude 'build/*' --exclude 'tests/*' --exclude 'benchmarks/*' --verbose
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        files: coverage_coro.xml
+        verbose: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build-release-thread-mode:
     runs-on: ubuntu-latest
     container:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,7 +56,8 @@
             "binaryDir": "${sourceDir}/build/debug_coro",
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/debug_coro",
-                "ENABLE_COROUTINE": "ON"
+                "ENABLE_COROUTINE": "ON",
+                "ENABLE_COVERAGE": "ON"
             }
         },
         {


### PR DESCRIPTION
<!-- PR Title format: feat|fix|perf|chore|revert: summary -->

## What's changed and how does it work?

This pull request adds support for code coverage reporting to the coroutine-enabled build and CI pipeline. The main changes include enabling coverage in the CMake preset and updating the CI workflow to generate and upload coverage reports to Codecov.

**Code coverage integration:**

* Enabled coverage reporting for the coroutine build by setting `ENABLE_COVERAGE` to `ON` in the `debug_coro` CMake preset in `CMakePresets.json`.
* Added steps in `.github/workflows/ci.yml` to generate a coverage report using `gcovr` and upload the results to Codecov after running unit tests for the coroutine build.